### PR TITLE
SA-456/add get feedback

### DIFF
--- a/api/models/feedback.py
+++ b/api/models/feedback.py
@@ -50,3 +50,18 @@ class FeedbackResultResponse(BaseModel):
     feedback_id: Optional[str] = Field(
         None, description="Unique identifier for the stored feedback"
     )
+
+
+class FeedbackWithId(FeedbackResult):
+    """Model for feedback result with document ID."""
+
+    document_id: str = Field(..., description="Firestore document ID")
+
+
+class ListFeedbacksResponse(BaseModel):
+    """Response model for list feedbacks endpoint."""
+
+    results: list[FeedbackWithId] = Field(
+        ..., description="List of matching feedback results"
+    )
+    count: int = Field(..., description="Number of results returned")

--- a/api/routes/v1/feedback.py
+++ b/api/routes/v1/feedback.py
@@ -5,8 +5,13 @@ import time
 from fastapi import APIRouter, HTTPException
 from survey_assist_utils.logging import get_logger
 
-from api.models.feedback import FeedbackResult, FeedbackResultResponse
-from api.services.feedback_service import store_feedback
+from api.models.feedback import (
+    FeedbackResult,
+    FeedbackResultResponse,
+    FeedbackWithId,
+    ListFeedbacksResponse,
+)
+from api.services.feedback_service import get_feedback, list_feedbacks, store_feedback
 
 router = APIRouter(tags=["Feedback"])
 
@@ -58,3 +63,137 @@ def store_feedback_endpoint(feedback_request: FeedbackResult) -> FeedbackResultR
     except Exception as e:
         logger.error(f"Error processing feedback: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.get("/feedback", response_model=FeedbackResult)
+async def get_feedback_endpoint(feedback_id: str) -> FeedbackResult:
+    """Retrieve a feedback result from Firestore by document ID.
+
+    Args:
+        feedback_id (str): The unique identifier of the feedback to retrieve.
+
+    Returns:
+        FeedbackResult: The retrieved feedback result.
+
+    Raises:
+        HTTPException: If the feedback is not found or there is an error retrieving it.
+    """
+    try:
+        start_time = time.perf_counter()
+        feedback_body_id = feedback_id
+        logger.info(
+            "Request received for feedback get",
+            feedback_id=str(feedback_id),
+            feedback_body_id=feedback_body_id,
+        )
+        feedback_data = get_feedback(feedback_id, correlation_id=feedback_body_id)
+        duration_ms = int((time.perf_counter() - start_time) * 1000)
+        logger.info(
+            "Response sent for feedback get",
+            feedback_id=str(feedback_id),
+            feedback_body_id=feedback_body_id,
+            duration_ms=str(duration_ms),
+        )
+        return FeedbackResult(**feedback_data)
+    except FileNotFoundError as e:
+        logger.warning(
+            f"Feedback not found: {feedback_id}",
+            feedback_body_id=feedback_body_id,
+        )
+        raise HTTPException(status_code=404, detail="Feedback not found") from e
+    except ValueError as e:
+        # pylint: disable=duplicate-code
+        logger.error(
+            f"Storage error retrieving feedback: {e}",
+            feedback_body_id=feedback_body_id,
+        )
+        raise HTTPException(
+            status_code=503, detail=f"Storage service unavailable: {e!s}"
+        ) from e
+    except RuntimeError as e:
+        # pylint: disable=duplicate-code
+        logger.error(
+            f"Storage service error retrieving feedback: {e}",
+            feedback_body_id=feedback_body_id,
+        )
+        raise HTTPException(
+            status_code=503, detail=f"Storage service error: {e!s}"
+        ) from e
+    except Exception as e:
+        logger.error(
+            f"Unexpected error retrieving feedback: {e}",
+            feedback_body_id=feedback_body_id,
+        )
+        # pylint: disable=duplicate-code
+        raise HTTPException(
+            status_code=500, detail=f"Internal server error: {e!s}"
+        ) from e
+
+
+@router.get("/feedbacks", response_model=ListFeedbacksResponse)
+async def list_feedbacks_endpoint(
+    survey_id: str, wave_id: str, case_id: str | None = None
+) -> ListFeedbacksResponse:
+    """List feedback results filtered by survey_id, wave_id, and optionally case_id.
+
+    Args:
+        survey_id (str): Survey identifier to filter by.
+        wave_id (str): Wave identifier to filter by.
+        case_id (str | None): Optional case identifier to filter by.
+            If None, returns all feedback for the survey/wave.
+
+    Returns:
+        ListFeedbacksResponse: List of matching feedback results with their document IDs.
+
+    Raises:
+        HTTPException: If there is an error retrieving the feedback results.
+    """
+    try:
+        start_time = time.perf_counter()
+        feedback_body_id = f"{survey_id}:{wave_id}:{case_id or ''}"
+        logger.info(
+            "Request received for feedbacks list",
+            survey_id=str(survey_id),
+            wave_id=str(wave_id),
+            case_id=str(case_id),
+            feedback_body_id=feedback_body_id,
+        )
+        feedbacks_data = list_feedbacks(
+            survey_id, wave_id, case_id, correlation_id=feedback_body_id
+        )
+        feedbacks = [FeedbackWithId(**data) for data in feedbacks_data]
+        duration_ms = int((time.perf_counter() - start_time) * 1000)
+        logger.info(
+            "Response sent for feedbacks list",
+            count=str(len(feedbacks)),
+            feedback_body_id=feedback_body_id,
+            duration_ms=str(duration_ms),
+        )
+        return ListFeedbacksResponse(results=feedbacks, count=len(feedbacks))
+    except ValueError as e:
+        # pylint: disable=duplicate-code
+        logger.error(
+            f"Storage error retrieving feedbacks: {e}",
+            feedback_body_id=feedback_body_id,
+        )
+        raise HTTPException(
+            status_code=503, detail=f"Storage service unavailable: {e!s}"
+        ) from e
+    except RuntimeError as e:
+        # pylint: disable=duplicate-code
+        logger.error(
+            f"Storage service error retrieving feedbacks: {e}",
+            feedback_body_id=feedback_body_id,
+        )
+        raise HTTPException(
+            status_code=503, detail=f"Storage service error: {e!s}"
+        ) from e
+    except Exception as e:
+        logger.error(
+            f"Unexpected error retrieving feedbacks: {e}",
+            feedback_body_id=feedback_body_id,
+        )
+        # pylint: disable=duplicate-code
+        raise HTTPException(
+            status_code=500, detail=f"Internal server error: {e!s}"
+        ) from e

--- a/api/routes/v1/feedback.py
+++ b/api/routes/v1/feedback.py
@@ -58,7 +58,7 @@ def store_feedback_endpoint(feedback_request: FeedbackResult) -> FeedbackResultR
             duration_ms=str(duration_ms),
         )
         return FeedbackResultResponse(
-            message="Feedback received successfully", feedback_id=document_id
+            message="Feedback stored successfully", feedback_id=document_id
         )
     except Exception as e:
         logger.error(f"Error processing feedback: {e}")

--- a/api/routes/v1/feedback.py
+++ b/api/routes/v1/feedback.py
@@ -151,6 +151,14 @@ async def list_feedbacks_endpoint(
     try:
         start_time = time.perf_counter()
         feedback_body_id = f"{survey_id}:{wave_id}:{case_id or ''}"
+        if not survey_id or not wave_id:
+            logger.warning(
+                "Request received for feedbacks list with missing survey_id or wave_id",
+                survey_id=str(survey_id),
+                wave_id=str(wave_id),
+                case_id=str(case_id),
+                feedback_body_id=feedback_body_id,
+            )
         logger.info(
             "Request received for feedbacks list",
             survey_id=str(survey_id),

--- a/api/routes/v1/result.py
+++ b/api/routes/v1/result.py
@@ -113,8 +113,7 @@ async def get_survey_result(result_id: str) -> SurveyAssistResult:
         ) from e
     except Exception as e:
         logger.error(
-            f"Unexpected error retrieving result: {e}",
-            result_body_id=result_body_id,
+            f"Unexpected error retrieving result: {e}", result_body_id=result_body_id
         )
         raise HTTPException(
             status_code=500, detail=f"Internal server error: {e!s}"

--- a/api/routes/v1/result.py
+++ b/api/routes/v1/result.py
@@ -141,6 +141,14 @@ async def list_survey_results(
     try:
         start_time = time.perf_counter()
         result_body_id = f"{survey_id}:{wave_id}:{case_id or ''}"
+        if not survey_id or not wave_id:
+            logger.warning(
+                "Request received for results list with missing survey_id or wave_id",
+                survey_id=str(survey_id),
+                wave_id=str(wave_id),
+                case_id=str(case_id),
+                result_body_id=result_body_id,
+            )
         logger.info(
             "Request received for results list",
             survey_id=str(survey_id),

--- a/api/services/feedback_service.py
+++ b/api/services/feedback_service.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from survey_assist_utils.logging import get_logger
 
-from api.services.firestore_client import get_firestore_client
+from api.services.firestore_client import get_firestore_client, retry_config
 
 logger = get_logger(__name__)
 
@@ -29,7 +29,73 @@ def store_feedback(feedback_data: dict[str, Any]) -> str:
     return doc_ref.id
 
 
-# Future development will include retrieval functions for analytics and reporting:
-# - get_feedback(feedback_id: str) -> dict[str, Any]
-# - list_feedback(survey_id: str, wave_id: str, case_id: str) -> list[dict[str, Any]]
-# - get_feedback_by_person(person_id: str) -> list[dict[str, Any]]
+def get_feedback(feedback_id: str, correlation_id: str | None = None) -> dict[str, Any]:
+    """Retrieve a feedback document from Firestore by ID.
+
+    Args:
+        feedback_id (str): Firestore document ID.
+        correlation_id (str | None): Optional correlation ID for request tracking.
+
+    Returns:
+        dict[str, Any]: The retrieved document data.
+
+    Raises:
+        FileNotFoundError: If the feedback document is not found.
+    """
+    db = get_firestore_client()
+    doc = db.collection("survey_feedback").document(feedback_id).get(retry=retry_config)
+    if not doc.exists:
+        raise FileNotFoundError(f"Feedback not found: {feedback_id}")
+    data = doc.to_dict()
+    logger.info(
+        f"Retrieved feedback id {feedback_id} from Firestore",
+        correlation_id=correlation_id,
+    )
+    return data
+
+
+def list_feedbacks(
+    survey_id: str,
+    wave_id: str,
+    case_id: str | None = None,
+    correlation_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """List feedback documents from Firestore filtered by survey_id, wave_id, and case_id.
+
+    Filters by survey_id, wave_id, and optionally case_id.
+
+    Args:
+        survey_id (str): Survey identifier to filter by.
+        wave_id (str): Wave identifier to filter by.
+        case_id (str | None): Optional case identifier to filter by.
+            If None, returns all feedback for the survey/wave.
+        correlation_id (str | None): Optional correlation ID for request tracking.
+
+    Returns:
+        list[dict[str, Any]]: List of matching feedback documents with their IDs.
+    """
+    db = get_firestore_client()
+    collection = db.collection("survey_feedback")
+
+    # Query documents where survey_id and wave_id match, optionally case_id
+    # pylint: disable=duplicate-code
+    query = collection.where("survey_id", "==", survey_id).where(
+        "wave_id", "==", wave_id
+    )
+
+    # Add case_id filter if provided
+    if case_id is not None:
+        query = query.where("case_id", "==", case_id)
+
+    results = []
+    for doc in query.stream():
+        data = doc.to_dict()
+        data["document_id"] = doc.id  # Include the Firestore document ID
+        results.append(data)
+
+    logger.info(
+        f"Retrieved {len(results)} feedback results for survey_id={survey_id}, "
+        f"wave_id={wave_id}, case_id={case_id}",
+        correlation_id=correlation_id,
+    )
+    return results

--- a/api/services/firestore_client.py
+++ b/api/services/firestore_client.py
@@ -5,10 +5,24 @@ from __future__ import annotations
 from typing import Any
 
 from firebase_admin import firestore, initialize_app  # type: ignore
+from google.api_core.exceptions import ServiceUnavailable
+from google.api_core.retry import Retry
+from survey_assist_utils.logging import get_logger
 
 from api.config import settings
 
 _db_client: Any = None
+logger = get_logger(__name__)
+
+# Configure retry for Firestore operations
+retry_config = Retry(
+    predicate=lambda exc: isinstance(exc, ServiceUnavailable),
+    initial=0.5,
+    maximum=10.0,
+    multiplier=1.5,
+    deadline=30.0,
+    on_error=lambda exc: logger.warning(f"Retrying due to: {exc}"),
+)
 
 
 def init_firestore_client() -> None:

--- a/api/services/result_service.py
+++ b/api/services/result_service.py
@@ -3,23 +3,11 @@
 from datetime import datetime
 from typing import Any
 
-from google.api_core.exceptions import ServiceUnavailable
-from google.api_core.retry import Retry
 from survey_assist_utils.logging import get_logger
 
-from api.services.firestore_client import get_firestore_client
+from api.services.firestore_client import get_firestore_client, retry_config
 
 logger = get_logger(__name__)
-
-# Configure retry for Firestore operations
-retry_config = Retry(
-    predicate=lambda exc: isinstance(exc, ServiceUnavailable),
-    initial=0.5,
-    maximum=10.0,
-    multiplier=1.5,
-    deadline=30.0,
-    on_error=lambda exc: logger.warning(f"Retrying due to: {exc}"),
-)
 
 
 def datetime_handler(obj):

--- a/docs/gcp_deployment.md
+++ b/docs/gcp_deployment.md
@@ -346,7 +346,12 @@ All endpoints are accessible via the API Gateway at `{API_GATEWAY_URL}/v1/survey
 - **Embeddings**: `embeddings` - Get vector store status and metadata
 - **SIC Lookup**: `sic-lookup` - Lookup SIC codes by description
 - **Classification**: `classify` - Classify job descriptions to SIC/SOC codes
-- **Results**: `result` - Store survey interaction results
+- **Results**: `result` - Store and retrieve survey interaction results
+  - `GET /result?result_id={id}` - Retrieve a result by ID
+  - `GET /results?survey_id={id}&wave_id={id}&case_id={id}` - List results by survey/wave/case
+- **Feedback**: `feedback` - Store and retrieve survey feedback
+  - `GET /feedback?feedback_id={id}` - Retrieve feedback by ID
+  - `GET /feedbacks?survey_id={id}&wave_id={id}&case_id={id}` - List feedback by survey/wave/case
 
 ## API Gateway Authentication with JWT Tokens
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -179,17 +179,18 @@ curl --header "Authorization: Bearer ${JWT_TOKEN}" \
   ```json
   {
     "message": "Result stored successfully",
-    "result_id": "test-survey-123/test.userSA187/2024-03-19/10_30_15.json"
+    "result_id": "abc123xyz456def789gh"
   }
   ```
+  Note: `result_id` is a Firestore document ID (auto-generated, 20-character alphanumeric string).
 
 ### Get Result Endpoint
 - **Base URL**: `http://localhost:8080`
 - **Path**: `/v1/survey-assist/result`
 - **Method**: GET
-- **Description**: Retrieves stored classification results
+- **Description**: Retrieves stored classification results by Firestore document ID
 - **Query Parameters**:
-  - `result_id` (required): The ID of the result to retrieve (e.g., "test-survey-123/test.userSA187/2024-03-19/10_30_15.json")
+  - `result_id` (required): The Firestore document ID of the result to retrieve (e.g., "abc123xyz456def789gh")
 - **Response**: Returns the stored result in the same format as the POST request body.
 
 ### Example Usage
@@ -241,8 +242,167 @@ curl -X POST "http://localhost:8080/v1/survey-assist/result" \
     ]
   }'
 
-# Retrieve a result
-curl -X GET "http://localhost:8080/v1/survey-assist/result?result_id=test-survey-123/test.userSA187/2024-03-19/10_30_15.json"
+# Retrieve a result by ID
+curl -X GET "http://localhost:8080/v1/survey-assist/result?result_id=abc123xyz456def789gh"
+
+# List results by survey/wave
+curl -X GET "http://localhost:8080/v1/survey-assist/results?survey_id=test-survey-123&wave_id=test-wave-001"
+
+# List results by survey/wave/case
+curl -X GET "http://localhost:8080/v1/survey-assist/results?survey_id=test-survey-123&wave_id=test-wave-001&case_id=test-case-456"
+```
+
+### List Results Endpoint
+- **Base URL**: `http://localhost:8080`
+- **Path**: `/v1/survey-assist/results`
+- **Method**: GET
+- **Description**: Lists survey results filtered by survey_id, wave_id, and optionally case_id
+- **Query Parameters**:
+  - `survey_id` (required): Survey identifier to filter by
+  - `wave_id` (required): Wave identifier to filter by
+  - `case_id` (optional): Case identifier to filter by. If not provided, returns all results for the survey/wave
+- **Response**: Returns a list of matching survey results with their document IDs:
+  ```json
+  {
+    "results": [
+      {
+        "survey_id": "test-survey-123",
+        "case_id": "test-case-456",
+        "wave_id": "test-wave-001",
+        "document_id": "abc123xyz",
+        "user": "test.user",
+        "time_start": "2024-03-19T10:00:00Z",
+        "time_end": "2024-03-19T10:05:00Z",
+        "responses": [...]
+      }
+    ],
+    "count": 1
+  }
+  ```
+
+### Feedback Endpoint
+- **Base URL**: `http://localhost:8080`
+- **Path**: `/v1/survey-assist/feedback`
+- **Method**: POST
+- **Description**: Stores feedback data from survey respondents
+- **Request Body**:
+  ```json
+  {
+    "case_id": "test-case-001",
+    "person_id": "test-person-001",
+    "survey_id": "test-survey-001",
+    "wave_id": "test-wave-001",
+    "questions": [
+      {
+        "response": "Very helpful",
+        "response_name": "satisfaction",
+        "response_options": ["Not helpful", "Somewhat helpful", "Very helpful", "Extremely helpful"]
+      },
+      {
+        "response": "Yes, I understood the classification",
+        "response_name": "understanding",
+        "response_options": null
+      }
+    ]
+  }
+  ```
+- **Response**: Returns stored feedback information:
+  ```json
+  {
+    "message": "Feedback received successfully",
+    "feedback_id": "xyz789abc123def456ij"
+  }
+  ```
+  Note: `feedback_id` is a Firestore document ID (auto-generated, 20-character alphanumeric string).
+
+### Get Feedback Endpoint
+- **Base URL**: `http://localhost:8080`
+- **Path**: `/v1/survey-assist/feedback`
+- **Method**: GET
+- **Description**: Retrieves a stored feedback result by Firestore document ID
+- **Query Parameters**:
+  - `feedback_id` (required): The Firestore document ID of the feedback to retrieve (e.g., "xyz789abc123def456ij")
+- **Response**: Returns the stored feedback in the same format as the POST request body:
+  ```json
+  {
+    "case_id": "test-case-001",
+    "person_id": "test-person-001",
+    "survey_id": "test-survey-001",
+    "wave_id": "test-wave-001",
+    "questions": [
+      {
+        "response": "Very helpful",
+        "response_name": "satisfaction",
+        "response_options": ["Not helpful", "Somewhat helpful", "Very helpful", "Extremely helpful"]
+      }
+    ]
+  }
+  ```
+
+### List Feedbacks Endpoint
+- **Base URL**: `http://localhost:8080`
+- **Path**: `/v1/survey-assist/feedbacks`
+- **Method**: GET
+- **Description**: Lists feedback results filtered by survey_id, wave_id, and optionally case_id
+- **Query Parameters**:
+  - `survey_id` (required): Survey identifier to filter by
+  - `wave_id` (required): Wave identifier to filter by
+  - `case_id` (optional): Case identifier to filter by. If not provided, returns all feedback for the survey/wave
+- **Response**: Returns a list of matching feedback results with their document IDs:
+  ```json
+  {
+    "results": [
+      {
+        "case_id": "test-case-001",
+        "person_id": "test-person-001",
+        "survey_id": "test-survey-001",
+        "wave_id": "test-wave-001",
+        "questions": [
+          {
+            "response": "Very helpful",
+            "response_name": "satisfaction",
+            "response_options": ["Not helpful", "Somewhat helpful", "Very helpful", "Extremely helpful"]
+          }
+        ],
+        "document_id": "xyz789abc123def456ij"
+      }
+    ],
+    "count": 1
+  }
+  ```
+
+### Feedback Example Usage
+```bash
+# Store feedback
+curl -X POST "http://localhost:8080/v1/survey-assist/feedback" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "case_id": "test-case-001",
+    "person_id": "test-person-001",
+    "survey_id": "test-survey-001",
+    "wave_id": "test-wave-001",
+    "questions": [
+      {
+        "response": "Very helpful",
+        "response_name": "satisfaction",
+        "response_options": ["Not helpful", "Somewhat helpful", "Very helpful", "Extremely helpful"]
+      },
+      {
+        "response": "Yes, I understood the classification",
+        "response_name": "understanding",
+        "response_options": null
+      }
+    ]
+  }'
+
+# Retrieve feedback by ID
+curl -X GET "http://localhost:8080/v1/survey-assist/feedback?feedback_id=xyz789abc123def456ij"
+
+# List all feedback for a survey/wave
+curl -X GET "http://localhost:8080/v1/survey-assist/feedbacks?survey_id=test-survey-001&wave_id=test-wave-001"
+
+# List feedback for a specific case
+curl -X GET "http://localhost:8080/v1/survey-assist/feedbacks?survey_id=test-survey-001&wave_id=test-wave-001&case_id=test-case-001"
 ```
 
 ### SIC Lookup Endpoint

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -309,7 +309,7 @@ curl -X GET "http://localhost:8080/v1/survey-assist/results?survey_id=test-surve
 - **Response**: Returns stored feedback information:
   ```json
   {
-    "message": "Feedback received successfully",
+    "message": "Feedback stored successfully",
     "feedback_id": "xyz789abc123def456ij"
   }
   ```

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -16,6 +16,30 @@ Functions:
     test_store_feedback_different_question_types():
         Tests storing feedback with different question types (radio and text).
 
+    test_get_feedback_success():
+        Tests successful retrieval of feedback by ID.
+
+    test_get_feedback_not_found():
+        Tests 404 error when feedback not found.
+
+    test_get_feedback_storage_error_valueerror():
+        Tests 503 error when storage service returns ValueError.
+
+    test_get_feedback_storage_error_runtimeerror():
+        Tests 503 error when storage service returns RuntimeError.
+
+    test_list_feedbacks_success():
+        Tests successful listing of feedbacks by survey_id and wave_id.
+
+    test_list_feedbacks_empty():
+        Tests listing feedbacks when no results are found.
+
+    test_list_feedbacks_storage_error_valueerror():
+        Tests 503 error when listing feedbacks and storage service returns ValueError.
+
+    test_list_feedbacks_storage_error_runtimeerror():
+        Tests 503 error when listing feedbacks and storage service returns RuntimeError.
+
 Dependencies:
     - pytest: Used for marking and running test cases.
     - fastapi.testclient.TestClient: Used to simulate HTTP requests to the FastAPI app.
@@ -332,3 +356,164 @@ def test_store_feedback_empty_questions_array():
         response = client.post("/v1/survey-assist/feedback", json=test_data)
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["message"] == "Feedback received successfully"
+
+
+def test_get_feedback_success():
+    """Test retrieving a stored feedback by ID.
+
+    This test verifies that:
+    1. A valid feedback ID can be retrieved successfully
+    2. The response contains the correct feedback data
+    """
+    test_feedback_data = {
+        "case_id": "0710-25AA-XXXX-YYYY",
+        "person_id": "000001_01",
+        "survey_id": "survey_123",
+        "wave_id": "wave_456",
+        "questions": [
+            {
+                "response": "Very satisfied",
+                "response_name": "satisfaction_question",
+                "response_options": [
+                    "Very satisfied",
+                    "Satisfied",
+                    "Neutral",
+                    "Dissatisfied",
+                    "Very dissatisfied",
+                ],
+            }
+        ],
+    }
+
+    with patch("api.routes.v1.feedback.get_feedback") as mock_get:
+        mock_get.return_value = test_feedback_data
+        response = client.get("/v1/survey-assist/feedback?feedback_id=fb123")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["case_id"] == "0710-25AA-XXXX-YYYY"
+        assert response.json()["survey_id"] == "survey_123"
+
+
+def test_get_feedback_not_found():
+    """Test retrieving a non-existent feedback.
+
+    This test verifies that:
+    1. Attempting to retrieve a non-existent feedback returns a 404 status code
+    """
+    with patch("api.routes.v1.feedback.get_feedback") as mock_get:
+        mock_get.side_effect = FileNotFoundError("Feedback not found")
+        response = client.get("/v1/survey-assist/feedback?feedback_id=non-existent")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json()["detail"] == "Feedback not found"
+
+
+def test_get_feedback_storage_error_valueerror():
+    """Test retrieving feedback when storage service returns ValueError.
+
+    This test verifies that:
+    1. A ValueError from storage service returns a 503 status code
+    """
+    with patch("api.routes.v1.feedback.get_feedback") as mock_get:
+        mock_get.side_effect = ValueError("Storage service unavailable")
+        response = client.get("/v1/survey-assist/feedback?feedback_id=fb123")
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "Storage service unavailable" in response.json()["detail"]
+
+
+def test_get_feedback_storage_error_runtimeerror():
+    """Test retrieving feedback when storage service returns RuntimeError.
+
+    This test verifies that:
+    1. A RuntimeError from storage service returns a 503 status code
+    """
+    with patch("api.routes.v1.feedback.get_feedback") as mock_get:
+        mock_get.side_effect = RuntimeError("Storage service error")
+        response = client.get("/v1/survey-assist/feedback?feedback_id=fb123")
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "Storage service error" in response.json()["detail"]
+
+
+def test_list_feedbacks_success():
+    """Test listing feedbacks by survey_id and wave_id.
+
+    This test verifies that:
+    1. Feedbacks can be retrieved by survey_id and wave_id
+    2. The response contains a list with document_id field included
+    """
+    expected_count = 2
+    mock_feedbacks_data = [
+        {
+            "case_id": "0710-25AA-XXXX-YYYY",
+            "person_id": "000001_01",
+            "survey_id": "survey_123",
+            "wave_id": "wave_456",
+            "questions": [],
+            "document_id": "fb123",
+        },
+        {
+            "case_id": "0710-25AA-XXXX-YYYY",
+            "person_id": "000002_01",
+            "survey_id": "survey_123",
+            "wave_id": "wave_456",
+            "questions": [],
+            "document_id": "fb456",
+        },
+    ]
+
+    with patch("api.routes.v1.feedback.list_feedbacks") as mock_list:
+        mock_list.return_value = mock_feedbacks_data
+        response = client.get(
+            "/v1/survey-assist/feedbacks?survey_id=survey_123&wave_id=wave_456"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["count"] == expected_count
+        assert len(data["results"]) == expected_count
+        assert data["results"][0]["document_id"] == "fb123"
+        assert data["results"][1]["document_id"] == "fb456"
+
+
+def test_list_feedbacks_empty():
+    """Test listing feedbacks when no feedbacks are found.
+
+    This test verifies that:
+    1. An empty list is returned when no feedbacks match the criteria
+    """
+    with patch("api.routes.v1.feedback.list_feedbacks") as mock_list:
+        mock_list.return_value = []
+        response = client.get(
+            "/v1/survey-assist/feedbacks?survey_id=survey_123&wave_id=wave_456"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["count"] == 0
+        assert len(data["results"]) == 0
+
+
+def test_list_feedbacks_storage_error_valueerror():
+    """Test listing feedbacks when storage service returns ValueError.
+
+    This test verifies that:
+    1. A ValueError from storage service returns a 503 status code
+    """
+    with patch("api.routes.v1.feedback.list_feedbacks") as mock_list:
+        mock_list.side_effect = ValueError("Storage service unavailable")
+        response = client.get(
+            "/v1/survey-assist/feedbacks?survey_id=survey_123&wave_id=wave_456"
+        )
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "Storage service unavailable" in response.json()["detail"]
+
+
+def test_list_feedbacks_storage_error_runtimeerror():
+    """Test listing feedbacks when storage service returns RuntimeError.
+
+    This test verifies that:
+    1. A RuntimeError from storage service returns a 503 status code
+    """
+    with patch("api.routes.v1.feedback.list_feedbacks") as mock_list:
+        mock_list.side_effect = RuntimeError("Storage service error")
+        response = client.get(
+            "/v1/survey-assist/feedbacks?survey_id=survey_123&wave_id=wave_456"
+        )
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "Storage service error" in response.json()["detail"]

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -31,6 +31,9 @@ Functions:
     test_list_feedbacks_success():
         Tests successful listing of feedbacks by survey_id and wave_id.
 
+    test_list_feedbacks_with_case_id():
+        Tests successful listing of feedbacks by survey_id, wave_id, and case_id.
+
     test_list_feedbacks_empty():
         Tests listing feedbacks when no results are found.
 
@@ -470,6 +473,39 @@ def test_list_feedbacks_success():
         assert len(data["results"]) == expected_count
         assert data["results"][0]["document_id"] == "fb123"
         assert data["results"][1]["document_id"] == "fb456"
+
+
+def test_list_feedbacks_with_case_id():
+    """Test listing feedbacks by survey_id, wave_id, and case_id.
+
+    This test verifies that:
+    1. Feedbacks can be retrieved by survey_id, wave_id, and case_id
+    2. The response contains a list with document_id field included
+    """
+    expected_count = 1
+    mock_feedbacks_data = [
+        {
+            "case_id": "0710-25AA-XXXX-YYYY",
+            "person_id": "000001_01",
+            "survey_id": "survey_123",
+            "wave_id": "wave_456",
+            "questions": [],
+            "document_id": "fb123",
+        }
+    ]
+
+    with patch("api.routes.v1.feedback.list_feedbacks") as mock_list:
+        mock_list.return_value = mock_feedbacks_data
+        response = client.get(
+            "/v1/survey-assist/feedbacks?"
+            "survey_id=survey_123&wave_id=wave_456&case_id=0710-25AA-XXXX-YYYY"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["count"] == expected_count
+        assert len(data["results"]) == expected_count
+        assert data["results"][0]["document_id"] == "fb123"
+        assert data["results"][0]["case_id"] == "0710-25AA-XXXX-YYYY"
 
 
 def test_list_feedbacks_empty():

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -98,7 +98,7 @@ def test_store_feedback_success():
         mock_db.return_value.collection.return_value.document.return_value.id = "fb123"
         response = client.post("/v1/survey-assist/feedback", json=test_data)
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()["message"] == "Feedback received successfully"
+    assert response.json()["message"] == "Feedback stored successfully"
     assert response.json()["feedback_id"] == "fb123"
 
 
@@ -193,7 +193,7 @@ def test_store_feedback_multiple_questions():
         mock_db.return_value.collection.return_value.document.return_value.id = "fb456"
         response = client.post("/v1/survey-assist/feedback", json=test_data)
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()["message"] == "Feedback received successfully"
+    assert response.json()["message"] == "Feedback stored successfully"
 
 
 def test_store_feedback_different_question_types():
@@ -238,7 +238,7 @@ def test_store_feedback_different_question_types():
         mock_db.return_value.collection.return_value.document.return_value.id = "fb789"
         response = client.post("/v1/survey-assist/feedback", json=test_data)
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()["message"] == "Feedback received successfully"
+    assert response.json()["message"] == "Feedback stored successfully"
 
 
 def test_store_feedback_missing_case_id():

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -358,7 +358,7 @@ def test_store_feedback_empty_questions_array():
         )
         response = client.post("/v1/survey-assist/feedback", json=test_data)
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()["message"] == "Feedback received successfully"
+    assert response.json()["message"] == "Feedback stored successfully"
 
 
 def test_get_feedback_success():


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

Add feedback retrieval endpoints to allow querying stored feedback by document ID, survey/wave, or survey/wave/case. This implementation aligns with the existing result endpoint pattern, enabling users to retrieve both survey results and associated feedback responses using the same query parameters.

## 📜 Changes Introduced

- [x] Add FeedbackWithId and ListFeedbacksResponse models for feedback retrieval
- [x] Implement GET /feedback endpoint to retrieve feedback by document ID
- [x] Implement GET /feedbacks endpoint to list feedbacks by survey_id, wave_id, and optionally case_id
- [x] Add get_feedback and list_feedbacks functions to feedback service
- [x] Centralise Firestore retry configuration in firestore_client module
- [x] Update result_service to use centralised retry configuration
- [x] Add comprehensive feedback retrieval endpoint documentation to guide.md
- [x] Update GCP deployment guide with feedback endpoint information
- [x] Update result endpoint examples to use Firestore document IDs instead of file paths

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [x] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

### Prerequisites
- API server running on `http://localhost:8080`
- Firestore configured with `FIRESTORE_DB_ID` environment variable set
- Vector store service running (for classification functionality)

### Test Feedback Retrieval Endpoints

**1. Store feedback:**
```bash
curl -X POST "http://localhost:8080/v1/survey-assist/feedback" \
  -H "Content-Type: application/json" \
  -d '{
    "case_id": "test-case-001",
    "person_id": "test-person-001",
    "survey_id": "test-survey-001",
    "wave_id": "test-wave-001",
    "questions": [
      {
        "response": "Very helpful",
        "response_name": "satisfaction",
        "response_options": ["Not helpful", "Somewhat helpful", "Very helpful", "Extremely helpful"]
      },
      {
        "response": "Yes, I understood the classification",
        "response_name": "understanding",
        "response_options": null
      }
    ]
  }'
```

**2. Retrieve feedback by ID:**
```bash
# Use the feedback_id returned from step 1
curl -X GET "http://localhost:8080/v1/survey-assist/feedback?feedback_id=xyz789abc123def456ij"
```

**3. List all feedback for a survey/wave:**
```bash
curl -X GET "http://localhost:8080/v1/survey-assist/feedbacks?survey_id=test-survey-001&wave_id=test-wave-001"
```

**4. List feedback for a specific case:**
```bash
curl -X GET "http://localhost:8080/v1/survey-assist/feedbacks?survey_id=test-survey-001&wave_id=test-wave-001&case_id=test-case-001"
```

### Test Combined Workflow (Result + Feedback)

**1. Store a result:**
```bash
curl -X POST "http://localhost:8080/v1/survey-assist/result" \
  -H "Content-Type: application/json" \
  -d '{
    "survey_id": "test-survey-001",
    "case_id": "test-case-001",
    "wave_id": "test-wave-001",
    "user": "test.user",
    "time_start": "2024-03-19T10:00:00Z",
    "time_end": "2024-03-19T10:05:00Z",
    "responses": [
      {
        "person_id": "test-person-001",
        "time_start": "2024-03-19T10:00:00Z",
        "time_end": "2024-03-19T10:01:00Z",
        "survey_assist_interactions": [
          {
            "type": "classify",
            "flavour": "sic",
            "time_start": "2024-03-19T10:00:00Z",
            "time_end": "2024-03-19T10:01:00Z",
            "input": [
              {
                "field": "job_title",
                "value": "Electrician"
              }
            ],
            "response": {
              "classified": true,
              "code": "432100",
              "description": "Electrical installation",
              "reasoning": "Based on job title and description",
              "candidates": [
                {
                  "code": "432100",
                  "description": "Electrical installation",
                  "likelihood": 0.95
                }
              ],
              "follow_up": {
                "questions": []
              }
            }
          }
        ]
      }
    ]
  }'
```

**2. Store associated feedback:**
```bash
curl -X POST "http://localhost:8080/v1/survey-assist/feedback" \
  -H "Content-Type: application/json" \
  -d '{
    "case_id": "test-case-001",
    "person_id": "test-person-001",
    "survey_id": "test-survey-001",
    "wave_id": "test-wave-001",
    "questions": [
      {
        "response": "Very helpful",
        "response_name": "satisfaction",
        "response_options": ["Not helpful", "Somewhat helpful", "Very helpful", "Extremely helpful"]
      },
      {
        "response": "Yes, I understood the classification",
        "response_name": "understanding",
        "response_options": null
      }
    ]
  }'
```

**3. Retrieve both result and feedback (by survey_id and wave_id):**
```bash
# Get result
curl -X GET "http://localhost:8080/v1/survey-assist/results?survey_id=test-survey-001&wave_id=test-wave-001"

# Get feedback
curl -X GET "http://localhost:8080/v1/survey-assist/feedbacks?survey_id=test-survey-001&wave_id=test-wave-001"
```

**4. Retrieve both result and feedback (by survey_id, wave_id, and case_id):**
```bash
# Get result
curl -X GET "http://localhost:8080/v1/survey-assist/results?survey_id=test-survey-001&wave_id=test-wave-001&case_id=test-case-001"

# Get feedback
curl -X GET "http://localhost:8080/v1/survey-assist/feedbacks?survey_id=test-survey-001&wave_id=test-wave-001&case_id=test-case-001"
```

### Expected Behaviour (Verified in PR Tests)

- GET /feedback returns full feedback document when valid ID is provided
- GET /feedbacks returns list of feedback documents with document_id field included

### Running Unit Tests

Run the test suite with:
```bash
make all-tests
```

All error scenarios for feedback retrieval endpoints are covered by automated unit tests:
- GET /feedback returns 404 when feedback not found
- GET /feedback returns 503 for storage service errors (ValueError and RuntimeError)
- GET /feedbacks returns 503 for storage service errors (ValueError and RuntimeError)
