### PR TITLE
SA-473/bug fix enable full candidate list

### DIFF
--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -366,7 +366,7 @@ async def _classify_sic(  # pylint: disable=unused-argument,too-many-locals
             )
             try:
                 # Pass all alt_candidates for the open question
-                candidates = (
+                alt_candidates = (
                     unambiguous_response.alt_candidates
                     if unambiguous_response.alt_candidates
                     else None
@@ -377,7 +377,7 @@ async def _classify_sic(  # pylint: disable=unused-argument,too-many-locals
                     industry_descr=classification_request.org_description or "",
                     job_title=classification_request.job_title,
                     job_description=classification_request.job_description,
-                    llm_output=candidates,
+                    llm_output=alt_candidates,
                 )
                 llm_duration2_ms = int((time.perf_counter() - llm_start2) * 1000)
                 logger.info(

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -366,18 +366,12 @@ async def _classify_sic(  # pylint: disable=unused-argument,too-many-locals
             )
             try:
                 # Pass all alt_candidates for the open question
-                alt_candidates = (
-                    unambiguous_response.alt_candidates
-                    if unambiguous_response.alt_candidates
-                    else None
-                )
-
                 llm_start2 = time.perf_counter()
                 open_question_response, _ = await llm.formulate_open_question(
                     industry_descr=classification_request.org_description or "",
                     job_title=classification_request.job_title,
                     job_description=classification_request.job_description,
-                    llm_output=alt_candidates,
+                    llm_output=unambiguous_response.alt_candidates,
                 )
                 llm_duration2_ms = int((time.perf_counter() - llm_start2) * 1000)
                 logger.info(

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -365,9 +365,9 @@ async def _classify_sic(  # pylint: disable=unused-argument,too-many-locals
                 body_id=body_id,
             )
             try:
-                # Create a SicCandidate from the first alt_candidate for the open question
-                first_candidate = (
-                    unambiguous_response.alt_candidates[0]
+                # Pass all alt_candidates for the open question
+                candidates = (
+                    unambiguous_response.alt_candidates
                     if unambiguous_response.alt_candidates
                     else None
                 )
@@ -377,7 +377,7 @@ async def _classify_sic(  # pylint: disable=unused-argument,too-many-locals
                     industry_descr=classification_request.org_description or "",
                     job_title=classification_request.job_title,
                     job_description=classification_request.job_description,
-                    llm_output=first_candidate,
+                    llm_output=candidates,
                 )
                 llm_duration2_ms = int((time.perf_counter() - llm_start2) * 1000)
                 logger.info(


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

Fixes a bug where only first candidate from unambiguous SIC classification response was passed to  `formulate_open_question` method, instead of the full list of alternative candidates. Ensures LLM has access to all candidate classifications when giving open questions.

## 📜 Changes Introduced

<!-- List key changes made in this PR. Consider bullet points for readability. -->

- [x] Bug fix (fix:) - Changed `formulate_open_question` to receive full list of candidates instead of just the first
- [ ] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [x] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

### API Test with curl

Make a classification request that triggers the open question flow (when no unambiguous SIC code match is found):

```bash
curl -X POST "http://localhost:8080/v1/survey-assist/classify" \
  -H "Content-Type: application/json" \
  -d '{
    "llm": "gemini",
    "type": "sic",
    "job_title": "General Manager",
    "job_description": "Managing various business operations and coordinating different departments",
    "org_description": "A company that does many different things"
  }'
```

**Expected Output:**
```json
{
  "requested_type": "sic",
  "results": [
    {
      "type": "sic",
      "classified": false,
      "followup": "What is your employer's main business activity?",
      "code": null,
      "description": null,
      "candidates": [
        {"code": "84110", "descriptive": "Local and central government", "likelihood": 0.1},
        {"code": "94110", "descriptive": "Business and employer membership organisation", "likelihood": 0.1},
        {"code": "25620", "descriptive": "Metal work and machining", "likelihood": 0.1},
        {"code": "66120", "descriptive": "Security and commodity contracts brokerage", "likelihood": 0.1},
        {"code": "36000", "descriptive": "Water supply services", "likelihood": 0.1}
      ],
      "reasoning": "..."
    }
  ]
}
```

**Verification:**
- The response contains multiple candidates (5 in this example) in the `candidates` array
- All candidates are considered when generating the `followup` question
- The `formulate_open_question` method receives the full list of `alt_candidates` not just the first one

### Automated Tests

Run the existing test suite:

```bash
poetry run pytest tests/test_classify.py::test_classify_followup_question -v
```
