### PR TITLE
SA-99/classify config prompt

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -7,6 +7,14 @@ from pydantic_settings import BaseSettings
 
 logger = logging.getLogger(__name__)
 
+# Prompt version constants
+# These identifiers match the version keys used in the config endpoint response
+# (see api/models/config.py ConfigResponse and api/routes/v1/config.py)
+PROMPT_VERSION_V1V2 = "v1v2"  # Original single-prompt approach using sa_rag_sic_code
+PROMPT_VERSION_V3 = "v3"  # Two-step using unambiguous + follow-up prompts
+DEFAULT_PROMPT_VERSION = PROMPT_VERSION_V1V2  # Original single prompt
+VALID_PROMPT_VERSIONS = [PROMPT_VERSION_V1V2, PROMPT_VERSION_V3]
+
 
 # pylint: disable=too-few-public-methods
 class Settings(BaseSettings):
@@ -18,6 +26,9 @@ class Settings(BaseSettings):
     # Data file paths - defaults to example datasets from sic-classification-library package
     SIC_LOOKUP_DATA_PATH: str | None = os.getenv("SIC_LOOKUP_DATA_PATH")
     SIC_REPHRASE_DATA_PATH: str | None = os.getenv("SIC_REPHRASE_DATA_PATH")
+
+    # Prompt version configuration
+    DEFAULT_PROMPT_VERSION: str = os.getenv("DEFAULT_PROMPT_VERSION", "v1v2")
 
     def __post_init__(self):
         """Post-initialisation hook to log warnings about missing environment variables."""

--- a/api/models/classify.py
+++ b/api/models/classify.py
@@ -79,6 +79,8 @@ class ClassificationRequest(BaseModel):
         job_description (str): Survey response for Job Description.
         org_description (Optional[str]): Survey response for Organisation / Industry Description.
         options (Optional[ClassificationOptions]): Optional classification options.
+        prompt_version (Optional[str]): Optional prompt version identifier. If not supplied,
+            uses default configured value (original single prompt).
     """
 
     llm: LLMModel
@@ -90,6 +92,10 @@ class ClassificationRequest(BaseModel):
     )
     options: Optional[ClassificationOptions] = Field(
         None, description="Optional classification options"
+    )
+    prompt_version: Optional[str] = Field(
+        None,
+        description="Unique string identifying a prompt version. If not supplied, uses default configured value.",
     )
 
 

--- a/api/models/classify.py
+++ b/api/models/classify.py
@@ -95,7 +95,10 @@ class ClassificationRequest(BaseModel):
     )
     prompt_version: Optional[str] = Field(
         None,
-        description="Unique string identifying a prompt version. If not supplied, uses default configured value.",
+        description=(
+            "Unique string identifying a prompt version. If not supplied, uses "
+            "default configured value."
+        ),
     )
 
 

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -97,21 +97,21 @@ class TestClassifyEndpoint:
         mock_rephrase_instance.get_rephrased_count.return_value = 0
         self.mock_rephrase_client.return_value = mock_rephrase_instance
 
-        mock_llm_instance = MagicMock()
-        mock_llm_instance.sa_rag_sic_code.return_value = (
-            MagicMock(
-                classified=True,
-                codable=True,
-                followup=None,
-                class_code=EXPECTED_SIC_CODE,
-                class_descriptive=EXPECTED_SIC_DESCRIPTION,
-                reasoning="Mocked reasoning",
-                alt_candidates=[],
-            ),
-            None,
-            None,
+        self.mock_llm.sa_rag_sic_code = AsyncMock(
+            return_value=(
+                MagicMock(
+                    classified=True,
+                    codable=True,
+                    followup=None,
+                    class_code=EXPECTED_SIC_CODE,
+                    class_descriptive=EXPECTED_SIC_DESCRIPTION,
+                    reasoning="Mocked reasoning",
+                    alt_candidates=[],
+                ),
+                None,
+                None,
+            )
         )
-        self.mock_llm.return_value = mock_llm_instance
 
     @pytest.mark.parametrize(
         "request_data,expected_status_code",
@@ -255,6 +255,7 @@ def test_classify_followup_question(  # pylint: disable=too-many-locals
         "job_title": "Installation Engineer",
         "job_description": "Installing various systems in buildings",
         "org_description": "Construction company",
+        "prompt_version": "v3",
     }
 
     logger.info("Testing follow-up question with data", request_data=request_data)
@@ -348,6 +349,7 @@ def test_classify_endpoint_success(
         "job_title": "Electrician",
         "job_description": "Installing and maintaining electrical systems in buildings",
         "org_description": "Electrical contracting company",
+        "prompt_version": "v3",
     }
 
     logger.info(
@@ -612,6 +614,7 @@ def test_classify_endpoint_rephrasing_enabled(
         "job_description": "Growing cereals and crops",
         "org_description": "Agricultural farm",
         "options": {"sic": {"rephrased": True}},
+        "prompt_version": "v3",
     }
 
     response = client.post("/v1/survey-assist/classify", json=request_data)
@@ -688,6 +691,7 @@ def test_classify_endpoint_rephrasing_disabled(
         "job_description": "Growing cereals and crops",
         "org_description": "Agricultural farm",
         "options": {"sic": {"rephrased": False}},
+        "prompt_version": "v3",
     }
 
     response = client.post("/v1/survey-assist/classify", json=request_data)
@@ -765,6 +769,7 @@ def test_classify_endpoint_rephrasing_default(
         "job_title": "Farmer",
         "job_description": "Growing cereals and crops",
         "org_description": "Agricultural farm",
+        "prompt_version": "v3",
     }
 
     response = client.post("/v1/survey-assist/classify", json=request_data)
@@ -908,6 +913,7 @@ def test_classify_endpoint_meta_field_exclusion(
         "job_title": "Electrician",
         "job_description": "Installing and maintaining electrical systems",
         "org_description": "Electrical contracting company",
+        "prompt_version": "v3",
     }
 
     response = client.post(
@@ -927,6 +933,7 @@ def test_classify_endpoint_meta_field_exclusion(
         "job_description": "Installing and maintaining electrical systems",
         "org_description": "Electrical contracting company",
         "options": {"sic": {"rephrased": True}},
+        "prompt_version": "v3",
     }
 
     response = client.post("/v1/survey-assist/classify", json=request_data_with_options)


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

Adds prompt-version support to the classify endpoint so clients can opt into either the legacy single-prompt flow or the new two-step flow. Includes request model updates, configurable prompt-version defaults/validation, and routing logic in the SIC classifier.

## 📜 Changes Introduced

- Added optional `prompt_version` to `ClassificationRequest`.
- Defined prompt-version constants/default config to keep backward compatibility.
- Added validation plus branching in `/classify` to run single- vs two-step SIC flows.
- Implemented the original single-prompt `sa_rag_sic_code` path alongside the two-step path.
- Exercised both flows via manual API tests (curl) ensuring validation errors and success cases.

- [x] Feature implementation (feat:) / bug fix (fix:) / refactoring (chore:) / documentation (docs:) / testing (test:)
- [ ] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

1. Start the Survey Assist API with the vector store running: `poetry run uvicorn api.main:app --host 0.0.0.0 --port 8000`.
2. **Default (single prompt)**  
   ```
   curl -X POST http://localhost:8000/v1/survey-assist/classify \
        -H "Content-Type: application/json" \
        -d '{"llm":"gemini","type":"sic","job_title":"Cafe owner","job_description":"Runs a small cafe","org_description":"Hospitality"}'
   ```
   Expect `classified:false` with `followup` populated (single-prompt flow).
3. **Two-step prompt**  
   ```
   curl -X POST http://localhost:8000/v1/survey-assist/classify \
        -H "Content-Type: application/json" \
        -d '{"llm":"gemini","type":"sic","job_title":"Electrician","job_description":"Installing electrical systems","org_description":"Construction","prompt_version":"v3"}'
   ```
   Expect `classified:true` with `followup:null` after the unambiguous step.
4. **Invalid prompt version**  
   ```
   curl -X POST http://localhost:8000/v1/survey-assist/classify \
        -H "Content-Type: application/json" \
        -d '{"llm":"gemini","type":"sic","job_title":"Electrician","job_description":"Installing electrical systems","org_description":"Construction","prompt_version":"v9"}'
   ```
   Expect HTTP 400 with an “Invalid prompt_version” message.
