### PR TITLE
SA-559/soc-lookup-client-pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Survey Assist API implemented in Fast API
 
 ## Features
 
-- Fast API with endpoints for lookup and classification of SIC (Standard Industrial Classifier)
+- Fast API with endpoints for lookup and classification of SIC (Standard Industrial Classification) and SOC (Standard Occupational Classification)
 - **Rephrasing Toggle**: Control SIC and SOC description rephrasing (where rephrase data exists) via API options for testing and development
 - **Firestore Integration**: Store survey results and feedback data in Google Cloud Firestore
 - **List Results Endpoint**: Query survey results
@@ -112,4 +112,5 @@ The API supports the following environment variables:
 - `SIC_LOOKUP_DATA_PATH`: Path to SIC lookup data file
 - `SIC_REPHRASE_DATA_PATH`: Path to SIC rephrase data file 
 - `SOC_REPHRASE_DATA_PATH`: Optional path to SOC rephrase data file; if unset, packaged example data from `soc-classification-library` is used.
+- `SOC_LOOKUP_DATA_PATH`: Optional path to SOC lookup CSV; if unset, packaged example data from `soc-classification-library` is used.
 - `SIC_VECTOR_STORE`: URL of the vector store service

--- a/api/main.py
+++ b/api/main.py
@@ -27,9 +27,11 @@ from api.routes.v1.embeddings import router as embeddings_router
 from api.routes.v1.feedback import router as feedback_router
 from api.routes.v1.result import router as result_router
 from api.routes.v1.sic_lookup import router as sic_lookup_router
+from api.routes.v1.soc_lookup import router as soc_lookup_router
 from api.services.firestore_client import init_firestore_client
 from api.services.sic_lookup_client import SICLookupClient
 from api.services.sic_rephrase_client import SICRephraseClient
+from api.services.soc_lookup_client import SOCLookupClient
 from api.services.soc_rephrase_client import SOCRephraseClient
 
 
@@ -61,6 +63,15 @@ async def lifespan(fastapi_app: FastAPI):
         )
     else:
         fastapi_app.state.sic_lookup_client = SICLookupClient()
+
+    # Create SOC lookup client
+    soc_lookup_data_path = os.getenv("SOC_LOOKUP_DATA_PATH")
+    if soc_lookup_data_path and soc_lookup_data_path.strip():
+        fastapi_app.state.soc_lookup_client = SOCLookupClient(
+            data_path=soc_lookup_data_path.strip()
+        )
+    else:
+        fastapi_app.state.soc_lookup_client = SOCLookupClient()
 
     # Create SIC rephrase client
     sic_rephrase_data_path = os.getenv("SIC_REPHRASE_DATA_PATH")
@@ -99,6 +110,7 @@ FastAPISwagger2(app)  # type: ignore
 app.include_router(config_router, prefix="/v1/survey-assist")
 app.include_router(embeddings_router, prefix="/v1/survey-assist")
 app.include_router(sic_lookup_router, prefix="/v1/survey-assist")
+app.include_router(soc_lookup_router, prefix="/v1/survey-assist")
 app.include_router(classify_router, prefix="/v1/survey-assist")
 app.include_router(result_router, prefix="/v1/survey-assist")
 app.include_router(feedback_router, prefix="/v1/survey-assist")

--- a/api/routes/v1/lookup_handlers.py
+++ b/api/routes/v1/lookup_handlers.py
@@ -1,0 +1,87 @@
+"""Shared request handling for classification lookup endpoints (SIC and SOC).
+
+Both SIC and SOC lookup routes use the same flow: validate description, call
+client.get_result, handle not found, log and return. This module holds that
+logic so the routes stay thin and duplicate-code lint is avoided.
+"""
+
+import time
+from typing import Any, Protocol
+
+from fastapi import HTTPException
+from survey_assist_utils.logging import get_logger
+
+from utils.survey import truncate_identifier
+
+logger = get_logger(__name__)
+
+
+class LookupClientProtocol(Protocol):  # pylint: disable=too-few-public-methods
+    """Protocol for lookup clients (SIC or SOC) used by the shared handler."""
+
+    def get_result(self, description: str, similarity: bool) -> dict[str, Any] | None:
+        """Return lookup result or None if not found."""
+        ...  # pylint: disable=unnecessary-ellipsis
+
+
+def execute_lookup_request(
+    description: str,
+    similarity: bool,
+    lookup_client: LookupClientProtocol,
+    endpoint_name: str,
+    code_label: str,
+) -> dict[str, Any]:
+    """Run a classification lookup request and return the result or raise.
+
+    Args:
+        description: The description to look up.
+        similarity: Whether to use similarity search.
+        lookup_client: Client with get_result(description, similarity).
+        endpoint_name: Label for logs (e.g. "sic-lookup", "soc-lookup").
+        code_label: Label for error messages (e.g. "SIC", "SOC").
+
+    Returns:
+        The lookup result dict.
+
+    Raises:
+        HTTPException: 400 if description is empty, 404 if no result.
+    """
+    start_time = time.perf_counter()
+    request_timestamp = int(time.time())
+    lookup_id = f"{truncate_identifier(description)}_{request_timestamp}"
+    logger.info(
+        f"Request received for {endpoint_name}",
+        description=truncate_identifier(description),
+        similarity=str(similarity),
+        lookup_id=lookup_id,
+    )
+
+    if not description:
+        logger.error(
+            f"Empty description provided in {code_label} lookup request",
+            lookup_id=lookup_id,
+        )
+        raise HTTPException(status_code=400, detail="Description cannot be empty")
+
+    result = lookup_client.get_result(description, similarity)
+    if not result:
+        logger.error(
+            f"No {code_label} code found for description: {description}",
+            lookup_id=lookup_id,
+        )
+        raise HTTPException(
+            status_code=404,
+            detail=f"No {code_label} code found for description: {description}",
+        )
+
+    duration_ms = int((time.perf_counter() - start_time) * 1000)
+    code = result.get("code") if isinstance(result, dict) else None
+    logger.info(
+        f"Response sent for {endpoint_name}",
+        found=str(bool(code)),
+        code=str(code or ""),
+        similarity=str(similarity),
+        duration_ms=str(duration_ms),
+        lookup_id=lookup_id,
+    )
+    return result

--- a/api/routes/v1/sic_lookup.py
+++ b/api/routes/v1/sic_lookup.py
@@ -4,16 +4,14 @@ This module contains the SIC lookup endpoint for the Survey Assist API.
 It defines the endpoint for looking up SIC codes based on descriptions.
 """
 
-import time
+# pylint: disable=duplicate-code  # SIC/SOC routes share structure by design
 
-from fastapi import APIRouter, Depends, HTTPException, Request
-from survey_assist_utils.logging import get_logger
+from fastapi import APIRouter, Depends, Request
 
+from api.routes.v1.lookup_handlers import execute_lookup_request
 from api.services.sic_lookup_client import SICLookupClient
-from utils.survey import truncate_identifier
 
 router = APIRouter(tags=["SIC Lookup"])
-logger = get_logger(__name__)
 
 
 def get_lookup_client(request: Request) -> SICLookupClient:
@@ -28,7 +26,6 @@ def get_lookup_client(request: Request) -> SICLookupClient:
     return request.app.state.sic_lookup_client
 
 
-# Define the dependency at module level
 lookup_client_dependency = Depends(get_lookup_client)
 
 
@@ -63,41 +60,10 @@ async def sic_lookup(
         }
     ```
     """
-    start_time = time.perf_counter()
-    request_timestamp = int(time.time())
-    lookup_id = f"{truncate_identifier(description)}_{request_timestamp}"
-    logger.info(
-        "Request received for sic-lookup",
-        description=truncate_identifier(description),
-        similarity=str(similarity),
-        lookup_id=lookup_id,
+    return execute_lookup_request(
+        description=description,
+        similarity=similarity,
+        lookup_client=lookup_client,
+        endpoint_name="sic-lookup",
+        code_label="SIC",
     )
-
-    if not description:
-        logger.error(
-            "Empty description provided in SIC lookup request", lookup_id=lookup_id
-        )
-        raise HTTPException(status_code=400, detail="Description cannot be empty")
-
-    result = lookup_client.get_result(description, similarity)
-    if not result:
-        logger.error(
-            f"No SIC code found for description: {description}", lookup_id=lookup_id
-        )
-        raise HTTPException(
-            status_code=404,
-            detail=f"No SIC code found for description: {description}",
-        )
-
-    # Match found - log the result
-    duration_ms = int((time.perf_counter() - start_time) * 1000)
-    code = result.get("code") if isinstance(result, dict) else None
-    logger.info(
-        "Response sent for sic-lookup",
-        found=str(bool(code)),
-        code=str(code or ""),
-        similarity=str(similarity),
-        duration_ms=str(duration_ms),
-        lookup_id=lookup_id,
-    )
-    return result

--- a/api/routes/v1/soc_lookup.py
+++ b/api/routes/v1/soc_lookup.py
@@ -1,0 +1,54 @@
+"""Module that provides the SOC lookup endpoint for the Survey Assist API.
+
+This module contains the SOC lookup endpoint for the Survey Assist API.
+It defines the endpoint for looking up SOC codes based on descriptions.
+"""
+
+# pylint: disable=duplicate-code  # SIC/SOC routes share structure by design
+
+from fastapi import APIRouter, Depends, Request
+
+from api.routes.v1.lookup_handlers import execute_lookup_request
+from api.services.soc_lookup_client import SOCLookupClient
+
+router = APIRouter(tags=["SOC Lookup"])
+
+
+def get_lookup_client(request: Request) -> SOCLookupClient:
+    """Get a SOC lookup client instance.
+
+    Args:
+        request: The FastAPI request object containing the app state.
+
+    Returns:
+        SOCLookupClient: A SOC lookup client instance.
+    """
+    return request.app.state.soc_lookup_client
+
+
+lookup_client_dependency = Depends(get_lookup_client)
+
+
+@router.get("/soc-lookup")
+async def soc_lookup(
+    description: str,
+    similarity: bool = False,
+    lookup_client: SOCLookupClient = lookup_client_dependency,
+):
+    """Lookup the SOC code for a given description.
+
+    Args:
+        description: The description to look up.
+        similarity: Whether to use similarity search. Defaults to False.
+        lookup_client: The SOC lookup client instance.
+
+    Returns:
+        dict: The SOC lookup result.
+    """
+    return execute_lookup_request(
+        description=description,
+        similarity=similarity,
+        lookup_client=lookup_client,
+        endpoint_name="soc-lookup",
+        code_label="SOC",
+    )

--- a/api/services/soc_lookup_client.py
+++ b/api/services/soc_lookup_client.py
@@ -51,7 +51,7 @@ class SOCLookupClient:
             str: Path to the SOC lookup data file.
         """
         return resolve_package_data_path(
-            "occupational_classification.example_data", "example_soc_lookup_data.csv"
+            "occupational_classification.data", "example_soc_lookup_data.csv"
         )
 
     def lookup(self, description: str) -> dict | None:

--- a/api/services/soc_lookup_client.py
+++ b/api/services/soc_lookup_client.py
@@ -1,0 +1,99 @@
+"""SOC lookup client service for the Survey Assist API.
+
+This module provides a client for the SOC lookup service, which is used to
+look up SOC codes and descriptions.
+"""
+
+import logging
+from pathlib import Path
+
+from occupational_classification.lookup.soc_lookup import SOCLookup
+
+from api.services.package_utils import resolve_package_data_path
+
+logger = logging.getLogger(__name__)
+
+
+class SOCLookupClient:
+    """Client for the SOC lookup service.
+
+    This class provides a client for the SOC lookup service, which is used to
+    look up SOC codes and descriptions.
+
+    Attributes:
+        lookup_service: The SOC lookup service instance.
+    """
+
+    def __init__(self, data_path: str | None = None) -> None:
+        """Initialise the SOC lookup client.
+
+        Args:
+            data_path: Path to the SOC data file for initialisation-time configuration.
+                If not provided, the default example lookup dataset path will be used.
+        """
+        resolved_path = self._get_default_path() if data_path is None else data_path
+
+        if isinstance(resolved_path, Path):
+            resolved_path = str(resolved_path)
+
+        self.lookup_service = SOCLookup(resolved_path)
+
+        logger.info(
+            "Loaded %d SOC lookup codes from %s",
+            self.get_soc_codes_count(),
+            resolved_path,
+        )
+
+    def _get_default_path(self) -> str:
+        """Get the default path to the SOC lookup data file.
+
+        Returns:
+            str: Path to the SOC lookup data file.
+        """
+        return resolve_package_data_path(
+            "occupational_classification.example_data", "example_soc_lookup_data.csv"
+        )
+
+    def lookup(self, description: str) -> dict | None:
+        """Look up a SOC code by description.
+
+        Args:
+            description: The description to look up.
+
+        Returns:
+            A dictionary containing the SOC code and description, or None if no match
+            was found.
+        """
+        return self.lookup_service.lookup(description)
+
+    def similarity_search(self, description: str) -> dict | None:
+        """Search for similar SOC codes by description.
+
+        Args:
+            description: The description to search for.
+
+        Returns:
+            A dictionary containing potential matches, or None if no matches were
+            found.
+        """
+        return self.lookup_service.lookup(description, similarity=True)
+
+    def get_result(self, description: str, similarity: bool = False) -> dict:
+        """Get the SOC lookup result for a given description.
+
+        Args:
+            description: The description to look up.
+            similarity: Whether to use similarity search. Defaults to False.
+
+        Returns:
+            dict: The SOC lookup result.
+        """
+        return self.lookup_service.lookup(description, similarity)
+
+    def get_soc_codes_count(self) -> int:
+        """Get the total number of SOC codes in the lookup service.
+
+        Returns:
+            int: The total number of SOC codes available in the lookup service.
+        """
+        return len(self.lookup_service.data)

--- a/api/services/soc_rephrase_client.py
+++ b/api/services/soc_rephrase_client.py
@@ -48,7 +48,7 @@ class SOCRephraseClient:
     def _get_default_path(self) -> str:
         """Get the default path to the rephrased SOC data file."""
         return resolve_package_data_path(
-            "occupational_classification.example_data",
+            "occupational_classification.data",
             "example_rephrased_soc_data.csv",
         )
 

--- a/docs/generic_classification.md
+++ b/docs/generic_classification.md
@@ -31,6 +31,12 @@ The classification process works as follows:
 
 This endpoint provides generic classification functionality that can handle SIC, SOC, or combined SIC+SOC classification.
 
+### SOC Lookup Endpoint
+
+**GET** `/v1/survey-assist/soc-lookup?description=<text>&similarity=<bool>`
+
+This endpoint performs SOC lookup by description (exact match by default, with optional similarity search), mirroring the existing SIC lookup pattern.
+
 ### Result Storage Endpoints
 
 The API provides endpoints for storing and retrieving survey results that can contain SIC and/or SOC classification data:

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -564,6 +564,85 @@ curl -X POST "http://localhost:8080/v1/survey-assist/feedback" \
   
   **Note**: The `description` field in the response contains the input description (lowercased). When a match is found, `code` contains the SIC code. The `potential_matches` object is only present when `similarity=true` and contains arrays of potential matches.
 
+#### Example usage
+
+```bash
+curl -i "http://localhost:8080/v1/survey-assist/sic-lookup?description=electrical%20installation&similarity=false"
+
+curl -i "http://localhost:8080/v1/survey-assist/sic-lookup?description=electrical%20installation&similarity=true"
+```
+
+### SOC Lookup Endpoint
+- **Path**: `/v1/survey-assist/soc-lookup`
+- **Method**: GET
+- **Parameters**:
+
+    - `description` (required): The occupation description to look up
+    - `similarity` (optional, default: false): Boolean flag for similarity search
+
+- **Description**: Performs SOC code lookup with two modes:
+
+    - Exact match (`similarity=false`): Returns exact matches only
+    - Similarity search (`similarity=true`): Returns similar matches using fuzzy matching
+
+- **Data Sources**:
+
+    - **Default**: Uses packaged example data from the `soc-classification-library` package
+    - **Custom**: Can be overridden by setting `SOC_LOOKUP_DATA_PATH` environment variable
+
+- **Response Structure**: The response structure varies based on whether a match is found and whether similarity search is used:
+  
+  **When a match is found (exact match):**
+  ```json
+  {
+    "code": "1111",
+    "description": "chief executives and senior officials",
+    "code_meta": null,
+    "code_major_group": "1",
+    "code_major_group_meta": null
+  }
+  ```
+  
+  **When no match is found (exact match):**
+  ```json
+  {
+    "description": "senior officials",
+    "code": null,
+    "code_meta": null,
+    "code_major_group": null,
+    "code_major_group_meta": null
+  }
+  ```
+  
+  **When similarity search is enabled (`similarity=true`):**
+  ```json
+  {
+    "description": "senior officials",
+    "code": null,
+    "code_meta": null,
+    "code_major_group": null,
+    "code_major_group_meta": null,
+    "potential_matches": {
+      "descriptions_count": 1,
+      "descriptions": ["chief executives and senior officials"],
+      "codes_count": 1,
+      "codes": ["1111"],
+      "major_groups_count": 1,
+      "major_groups": []
+    }
+  }
+  ```
+  
+  **Note**: The `description` field in the response contains the input description (lowercased). When a match is found, `code` contains the SOC code. The `potential_matches` object is only present when `similarity=true` and contains arrays of potential matches.
+
+#### Example usage
+
+```bash
+curl -i "http://localhost:8080/v1/survey-assist/soc-lookup?description=chief%20executives%20and%20senior%20officials&similarity=false"
+
+curl -i "http://localhost:8080/v1/survey-assist/soc-lookup?description=senior%20officials&similarity=true"
+```
+
 ### Embeddings Endpoint
 - **Path**: `/v1/survey-assist/embeddings`
 - **Method**: GET

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,12 @@
 # Survey Assist API
 
-The Survey Assist API is a FastAPI service that provides access to classification services to determine which industry or occupation a respondent works in. Standard Industrial Code (SIC) classification is implemented using a direct lookup against an internal knowledge-base and if the classification cannot be made directly an LLM will attempt to unambiguously classify or provide a follow up question to gain further information. Standard Occupation Classification (SOC) is a future enhancement and the current endpoint will only return a template SOC response. The API provides endpoints to allow the client to store classification results and feedback in a Firestore database.
+The Survey Assist API is a FastAPI service that provides endpoints for both SIC (industry) and SOC (occupation) classification and lookup. Classification uses a vector-store shortlist plus an LLM to either return a code or ask a follow-up question; lookup provides a direct code lookup by description (with optional similarity search). The API also provides endpoints to store classification results and feedback in Firestore.
 
 ## Key Features
 
 - **SIC classification**: `POST /v1/survey-assist/classify` performs a two-step SIC classification using a vector-store shortlist and a Gemini LLM.
 - **SIC lookup**: `GET /v1/survey-assist/sic-lookup` looks up SIC codes by description (with optional similarity search).
+- **SOC lookup**: `GET /v1/survey-assist/soc-lookup` looks up SOC codes by description (with optional similarity search).
 - **Vector store status**: `GET /v1/survey-assist/embeddings` checks whether SIC embeddings are ready to query.
 - **Configuration introspection**: `GET /v1/survey-assist/config` returns the LLM model name, embedding model (from the vector store), and prompt templates.
 - **Firestore-backed persistence (optional)**:
@@ -31,10 +32,6 @@ For detailed information on installation, setup, and usage, please refer to the 
 - **`SIC_REPHRASE_DATA_PATH`**: Optional path to a rephrased SIC CSV. If unset, packaged example data is used.
 - **`FIRESTORE_DB_ID`**: Enables Firestore-backed endpoints when set; if unset, result/feedback endpoints will fail because the Firestore client is not initialised.
 - **`GCP_PROJECT_ID`**: Optional; used when initialising Firestore.
-
-## Notes
-
-- **SOC classification availability**: SOC classification uses the SOC vector store and a SOC LLM when these services are configured. If the SOC LLM is not available, requests with `type="soc"`/`"sic_soc"` will return a 503 `"SOC classification is not available"` error. SOC rephrasing is available for SOC codes that appear in the SOC rephrase dataset provided by `soc-classification-library`.
 
 ## Further reading
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Survey Assist API
 
-The Survey Assist API is a FastAPI service that provides endpoints for both SIC (industry) and SOC (occupation) classification and lookup. Classification uses a vector-store shortlist plus an LLM to either return a code or ask a follow-up question; lookup provides a direct code lookup by description (with optional similarity search). The API also provides endpoints to store classification results and feedback in Firestore.
+The Survey Assist API is a FastAPI service that provides endpoints for both SIC (industry) and SOC (occupation) classification and lookup. Classification uses a vector-store shortlist plus an LLM to either return a code or ask a follow-up question and lookup provides a direct code lookup by description (with optional similarity search). The API also provides endpoints to store classification results and feedback in Firestore.
 
 ## Key Features
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -7544,7 +7544,7 @@ files = [
 
 [[package]]
 name = "soc-classification-library"
-version = "0.1.2"
+version = "0.1.4"
 description = "Standard Occupational Classification library"
 optional = false
 python-versions = "^3.12"
@@ -7562,12 +7562,12 @@ toml = "^0.10.2"
 [package.source]
 type = "git"
 url = "https://github.com/ONSdigital/soc-classification-library.git"
-reference = "HEAD"
-resolved_reference = "52b70516b139e6d9e8eed6c52d80e843b6bb26e3"
+reference = "v0.1.4"
+resolved_reference = "c920e74754b027bd5e59e93eb9be5e0088368f4b"
 
 [[package]]
 name = "soc-classification-utils"
-version = "0.1.0"
+version = "0.1.1"
 description = "Utility functions used for SOC classification"
 optional = false
 python-versions = "^3.12"
@@ -7592,7 +7592,7 @@ pandas = "^2.3.0"
 posthog = ">=2.4.0,<6.0.0"
 pydantic = "^2.11.1"
 sentence-transformers = "4.1.0"
-soc-classification-library = {git = "https://github.com/ONSdigital/soc-classification-library.git"}
+soc-classification-library = {git = "https://github.com/ONSdigital/soc-classification-library.git", tag = "v0.1.4"}
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.7"}
 torch = "2.7.1"
 transformers = "4.48.0"
@@ -7600,8 +7600,8 @@ transformers = "4.48.0"
 [package.source]
 type = "git"
 url = "https://github.com/ONSdigital/soc-classification-utils.git"
-reference = "v0.1.1"
-resolved_reference = "fe570410f78e14ae93345b2c8721203ab599309c"
+reference = "HEAD"
+resolved_reference = "7b53e5a99a2602b2706e66a574531370204abeac"
 
 [[package]]
 name = "sqlalchemy"
@@ -8972,4 +8972,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "022ee3faea63d859ec4eb87497a2e5d262ccdd116445660b26aeba62623cce27"
+content-hash = "75ca7c9b28b4186107a7ae9371823722780cc8566654c0f5545f8c79ea41b382"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ google-auth = "^2.28.0"
 fastapi_swagger2 = "^0.2.4"
 sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.3"}
 sic-classification-utils = {git = "https://github.com/ONSdigital/sic-classification-utils.git", tag = "v0.1.9"}
-soc-classification-utils = { git = "https://github.com/ONSdigital/soc-classification-utils.git", tag = "v0.1.1" }
+soc-classification-library = { path = "../soc-classification-library" }
+soc-classification-utils = { path = "../soc-classification-utils" }
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.7"}
 firebase-admin = "^6.5.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ google-auth = "^2.28.0"
 fastapi_swagger2 = "^0.2.4"
 sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.3"}
 sic-classification-utils = {git = "https://github.com/ONSdigital/sic-classification-utils.git", tag = "v0.1.9"}
-soc-classification-library = { path = "../soc-classification-library" }
-soc-classification-utils = { path = "../soc-classification-utils" }
+soc-classification-library = { git = "https://github.com/ONSdigital/soc-classification-library.git", tag = "v0.1.4" }
+soc-classification-utils = { git = "https://github.com/ONSdigital/soc-classification-utils.git" }
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.7"}
 firebase-admin = "^6.5.0"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from survey_assist_utils.logging import get_logger
 from api.main import app
 from api.services.sic_lookup_client import SICLookupClient
 from api.services.sic_rephrase_client import SICRephraseClient
+from api.services.soc_lookup_client import SOCLookupClient
 
 try:
     from occupational_classification_utils.llm.llm import (
@@ -71,6 +72,10 @@ def pytest_configure(config):  # pylint: disable=unused-argument
     mock_sic_lookup_client = MagicMock(spec=SICLookupClient)
     mock_sic_lookup_client.get_sic_codes_count.return_value = 1000
 
+    # Mock the SOC lookup client
+    mock_soc_lookup_client = MagicMock(spec=SOCLookupClient)
+    mock_soc_lookup_client.get_soc_codes_count.return_value = 500
+
     # Mock the SIC rephrase client
     mock_sic_rephrase_client = MagicMock(spec=SICRephraseClient)
     mock_sic_rephrase_client.get_rephrased_count.return_value = 500
@@ -106,6 +111,7 @@ def pytest_configure(config):  # pylint: disable=unused-argument
     app.state.gemini_llm = mock_llm
     app.state.soc_llm = mock_soc_llm
     app.state.sic_lookup_client = mock_sic_lookup_client
+    app.state.soc_lookup_client = mock_soc_lookup_client
     app.state.sic_rephrase_client = mock_sic_rephrase_client
 
     logger.info("Global Test Configuration Applied")

--- a/tests/test_lookup_client_common.py
+++ b/tests/test_lookup_client_common.py
@@ -1,0 +1,68 @@
+"""Shared test helpers for SIC and SOC lookup client tests.
+
+Used to avoid duplicate-code (e.g. pylint R0801) between test_sic_lookup_client
+and test_soc_lookup_client while keeping behaviour aligned.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+
+@dataclass(frozen=True)
+class DataLoadingLoggingConfig:
+    """Config for assert_data_loading_logging (avoids too many function args)."""
+
+    lookup_patch_path: str
+    logger_patch_path: str
+    expected_count: int
+    codes_substring: str
+    set_get_codes_count: bool = False
+
+
+def assert_data_loading_logging(
+    client_class: type[Any],
+    config: DataLoadingLoggingConfig,
+) -> None:
+    """Assert that client init logs a message containing the count and codes label.
+
+    Both SIC and SOC lookup clients log on init (e.g. "Loaded N SIC lookup codes
+    from ..."). This helper runs that init under patched lookup and logger, captures
+    the log call, and asserts the message (after format) contains expected_count
+    and codes_substring.
+    """
+    with patch(config.lookup_patch_path) as mock_lookup:
+        mock_instance = mock_lookup.return_value
+        mock_instance.data = MagicMock()
+        mock_instance.data.__len__.return_value = config.expected_count
+        if config.set_get_codes_count:
+            mock_instance.get_sic_codes_count.return_value = config.expected_count
+
+        with patch(config.logger_patch_path) as mock_logger:
+            captured_message: str | None = None
+            captured_args: tuple[Any, ...] | None = None
+
+            def mock_info(message: str, *args: Any) -> None:
+                nonlocal captured_message, captured_args
+                captured_message = message
+                captured_args = args
+
+            mock_logger.info.side_effect = mock_info
+
+            client_class()
+
+            mock_logger.info.assert_called()
+            assert captured_message is not None
+            assert isinstance(captured_message, str)
+            msg: str = captured_message
+            # pylint: disable=unsupported-membership-test  # msg is str after assert above
+            assert "Loaded" in msg
+            assert config.codes_substring in msg
+            if captured_args:
+                formatted_message = msg % captured_args
+                assert str(config.expected_count) in formatted_message
+                assert config.codes_substring in formatted_message
+            else:
+                assert str(config.expected_count) in msg
+                assert config.codes_substring in msg
+            # pylint: enable=unsupported-membership-test

--- a/tests/test_sic_lookup_client.py
+++ b/tests/test_sic_lookup_client.py
@@ -4,12 +4,15 @@ This module contains pytest-based unit tests for the SICLookupClient class, whic
 provides SIC code lookup functionality.
 """
 
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from api.services.sic_lookup_client import SICLookupClient
+from tests.test_lookup_client_common import (
+    DataLoadingLoggingConfig,
+    assert_data_loading_logging,
+)
 
 # Test constants
 EXPECTED_SIC_CODE_COUNT = 250
@@ -215,41 +218,16 @@ class TestSICLookupClient:
 
     def test_data_loading_confirmation(self):
         """Test that data loading is confirmed with logging."""
-        with patch("api.services.sic_lookup_client.SICLookup") as mock_lookup:
-            mock_instance = mock_lookup.return_value
-            mock_instance.get_sic_codes_count.return_value = 150
-            mock_instance.data = MagicMock()
-            mock_instance.data.__len__.return_value = 150
-
-            with patch("api.services.sic_lookup_client.logger") as mock_logger:
-                # Capture the logged message
-                captured_message: str | None = None
-                captured_args: tuple[Any, ...] | None = None
-
-                def mock_info(message: str, *args: Any) -> None:
-                    nonlocal captured_message, captured_args
-                    captured_message = message
-                    captured_args = args
-
-                mock_logger.info.side_effect = mock_info
-
-                SICLookupClient()
-
-                # Verify logging message was called
-                mock_logger.info.assert_called()
-                # Check the captured message and format it
-                assert captured_message is not None
-                assert isinstance(captured_message, str)
-                # pylint: disable=unsupported-membership-test
-                assert "Loaded" in captured_message
-                assert "SIC lookup codes from" in captured_message
-                if captured_args:
-                    formatted_message = captured_message % captured_args
-                    assert "150" in formatted_message
-                    assert "SIC lookup codes from" in formatted_message
-                else:
-                    assert "150" in captured_message
-                    assert "SIC lookup codes from" in captured_message
+        assert_data_loading_logging(
+            SICLookupClient,
+            DataLoadingLoggingConfig(
+                lookup_patch_path="api.services.sic_lookup_client.SICLookup",
+                logger_patch_path="api.services.sic_lookup_client.logger",
+                expected_count=150,
+                codes_substring="SIC lookup codes from",
+                set_get_codes_count=True,
+            ),
+        )
 
 
 # Test the actual API endpoints

--- a/tests/test_soc_lookup_client.py
+++ b/tests/test_soc_lookup_client.py
@@ -1,0 +1,145 @@
+"""Tests for the SOCLookupClient class."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.services.soc_lookup_client import SOCLookupClient
+from tests.test_lookup_client_common import (
+    DataLoadingLoggingConfig,
+    assert_data_loading_logging,
+)
+
+# Test constants (mirror test_sic_lookup_client.py EXPECTED_SIC_CODE_COUNT)
+EXPECTED_SOC_CODE_COUNT = 10
+
+
+class TestSOCLookupClient:
+    """Test cases for the SOCLookupClient class."""
+
+    def test_init_with_custom_path(self):
+        """Test initialisation with a custom data path."""
+        custom_path = "/custom/path/soc_lookup.csv"
+
+        with patch("api.services.soc_lookup_client.SOCLookup") as mock_lookup:
+            mock_instance = mock_lookup.return_value
+            mock_instance.data = MagicMock()
+            mock_instance.data.__len__.return_value = 10
+
+            client = SOCLookupClient(data_path=custom_path)
+
+            mock_lookup.assert_called_once_with(custom_path)
+            assert client.lookup_service == mock_instance
+
+    def test_init_with_default_package_path(self):
+        """Test initialisation using package data path."""
+        with patch("api.services.soc_lookup_client.SOCLookup") as mock_lookup, patch(
+            "api.services.soc_lookup_client.resolve_package_data_path"
+        ) as mock_resolve:
+            mock_resolve.return_value = (
+                "/package/path/occupational_classification/example_data/"
+                "example_soc_lookup_data.csv"
+            )
+            mock_instance = mock_lookup.return_value
+            mock_instance.data = MagicMock()
+            mock_instance.data.__len__.return_value = 10
+
+            SOCLookupClient()
+
+            mock_lookup.assert_called_once()
+            called_path = mock_lookup.call_args[0][0]
+            assert "example_soc_lookup_data.csv" in called_path
+            mock_resolve.assert_called_once_with(
+                "occupational_classification.example_data",
+                "example_soc_lookup_data.csv",
+            )
+
+    def test_lookup_success(self):
+        """Test successful lookup operation."""
+        with patch("api.services.soc_lookup_client.SOCLookup") as mock_lookup:
+            mock_instance = mock_lookup.return_value
+            mock_instance.lookup.return_value = {
+                "code": "1111",
+                "description": "senior officials and managers",
+            }
+            mock_instance.data = MagicMock()
+            mock_instance.data.__len__.return_value = 10
+
+            client = SOCLookupClient()
+            result = client.lookup("senior officials and managers")
+
+            assert result == {
+                "code": "1111",
+                "description": "senior officials and managers",
+            }
+            mock_instance.lookup.assert_called_once_with(
+                "senior officials and managers"
+            )
+
+    def test_lookup_no_match(self):
+        """Test lookup when no match is found."""
+        with patch("api.services.soc_lookup_client.SOCLookup") as mock_lookup:
+            mock_instance = mock_lookup.return_value
+            mock_instance.lookup.return_value = None
+            mock_instance.data = MagicMock()
+            mock_instance.data.__len__.return_value = 10
+
+            client = SOCLookupClient()
+            result = client.lookup("nonexistent description")
+
+            assert result is None
+            mock_instance.lookup.assert_called_once_with("nonexistent description")
+
+    def test_lookup_with_similarity(self):
+        """Test lookup with similarity search enabled."""
+        with patch("api.services.soc_lookup_client.SOCLookup") as mock_lookup:
+            mock_instance = mock_lookup.return_value
+            mock_instance.lookup.return_value = {
+                "code": "1111",
+                "description": "senior officials and managers",
+            }
+            mock_instance.data = MagicMock()
+            mock_instance.data.__len__.return_value = 10
+
+            client = SOCLookupClient()
+            result = client.similarity_search("senior officials")
+
+            assert result == {
+                "code": "1111",
+                "description": "senior officials and managers",
+            }
+            mock_instance.lookup.assert_called_once_with(
+                "senior officials", similarity=True
+            )
+
+    def test_get_soc_codes_count(self):
+        """Test getting the count of available SOC codes."""
+        with patch("api.services.soc_lookup_client.SOCLookup") as mock_lookup:
+            mock_instance = mock_lookup.return_value
+            mock_instance.data = MagicMock()
+            mock_instance.data.__len__.return_value = EXPECTED_SOC_CODE_COUNT
+
+            client = SOCLookupClient()
+            count = client.get_soc_codes_count()
+
+            assert count == EXPECTED_SOC_CODE_COUNT
+
+    def test_initialization_error_handling(self):
+        """Test error handling during client initialization."""
+        with patch("api.services.soc_lookup_client.SOCLookup") as mock_lookup:
+            mock_lookup.side_effect = FileNotFoundError("SOC data file not found")
+
+            with pytest.raises(FileNotFoundError, match="SOC data file not found"):
+                SOCLookupClient()
+
+    def test_data_loading_confirmation_logging(self):
+        """Test that data loading is confirmed with logging."""
+        assert_data_loading_logging(
+            SOCLookupClient,
+            DataLoadingLoggingConfig(
+                lookup_patch_path="api.services.soc_lookup_client.SOCLookup",
+                logger_patch_path="api.services.soc_lookup_client.logger",
+                expected_count=7,
+                codes_substring="SOC lookup codes from",
+            ),
+        )

--- a/tests/test_soc_lookup_client.py
+++ b/tests/test_soc_lookup_client.py
@@ -37,7 +37,7 @@ class TestSOCLookupClient:
             "api.services.soc_lookup_client.resolve_package_data_path"
         ) as mock_resolve:
             mock_resolve.return_value = (
-                "/package/path/occupational_classification/example_data/"
+                "/package/path/occupational_classification/data/"
                 "example_soc_lookup_data.csv"
             )
             mock_instance = mock_lookup.return_value
@@ -50,7 +50,7 @@ class TestSOCLookupClient:
             called_path = mock_lookup.call_args[0][0]
             assert "example_soc_lookup_data.csv" in called_path
             mock_resolve.assert_called_once_with(
-                "occupational_classification.example_data",
+                "occupational_classification.data",
                 "example_soc_lookup_data.csv",
             )
 

--- a/tests/test_soc_lookup_endpoint.py
+++ b/tests/test_soc_lookup_endpoint.py
@@ -1,0 +1,103 @@
+"""Tests for the /soc-lookup endpoint."""
+
+from unittest.mock import MagicMock
+
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.routes.v1.soc_lookup import get_lookup_client
+
+
+def _setup_soc_lookup_override(mock_client):
+    """Helper to override the SOC lookup dependency with a mock."""
+    app.dependency_overrides[get_lookup_client] = lambda: mock_client
+
+
+def test_soc_lookup_exact_match():
+    """Test the SOC Lookup functionality with an exact match."""
+    mock_client = MagicMock()
+    mock_client.get_result.return_value = {
+        "description": "senior officials and managers",
+        "code": "1111",
+        "code_major_group": "1",
+    }
+    _setup_soc_lookup_override(mock_client)
+
+    client = TestClient(app)
+    response = client.get(
+        "/v1/survey-assist/soc-lookup",
+        params={"description": "senior officials and managers", "similarity": "false"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["code"] == "1111"
+    assert body["description"] == "senior officials and managers"
+    mock_client.get_result.assert_called_once_with(
+        "senior officials and managers", False
+    )
+
+
+def test_soc_lookup_similarity():
+    """Test the SOC Lookup functionality with similarity search enabled."""
+    mock_client = MagicMock()
+    mock_client.get_result.return_value = {
+        "description": "senior officials and managers",
+        "code": "1111",
+        "code_major_group": "1",
+        "potential_matches": {
+            "descriptions": [
+                "senior officials and managers",
+                "production or operations managers",
+            ],
+            "codes": ["1111", "1112"],
+        },
+    }
+    _setup_soc_lookup_override(mock_client)
+
+    client = TestClient(app)
+    response = client.get(
+        "/v1/survey-assist/soc-lookup",
+        params={"description": "senior officials", "similarity": "true"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert body["code"] == "1111"
+    assert "potential_matches" in body
+    assert body["potential_matches"]["codes"] == ["1111", "1112"]
+    mock_client.get_result.assert_called_once_with("senior officials", True)
+
+
+def test_soc_lookup_no_description():
+    """Test the SOC Lookup functionality when no description is provided."""
+    mock_client = MagicMock()
+    _setup_soc_lookup_override(mock_client)
+
+    client = TestClient(app)
+    response = client.get(
+        "/v1/survey-assist/soc-lookup",
+        params={"description": "", "similarity": "false"},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    body = response.json()
+    assert body["detail"] == "Description cannot be empty"
+
+
+def test_soc_lookup_not_found():
+    """Test the SOC Lookup functionality when no result is found."""
+    mock_client = MagicMock()
+    mock_client.get_result.return_value = None
+    _setup_soc_lookup_override(mock_client)
+
+    client = TestClient(app)
+    response = client.get(
+        "/v1/survey-assist/soc-lookup",
+        params={"description": "unknown title", "similarity": "false"},
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    body = response.json()
+    assert body["detail"] == "No SOC code found for description: unknown title"

--- a/tests/test_soc_rephrase_client.py
+++ b/tests/test_soc_rephrase_client.py
@@ -72,7 +72,7 @@ class TestSOCRephraseClient:
             call_path = mock_read_csv.call_args[0][0]
             assert "/package/path/example_rephrased_soc_data.csv" in call_path
             mock_resolve.assert_called_once_with(
-                "occupational_classification.example_data",
+                "occupational_classification.data",
                 "example_rephrased_soc_data.csv",
             )
 


### PR DESCRIPTION
# 📌 Pull Request

## ✨ Summary

Introduce a SOC lookup client and `/soc-lookup` FastAPI endpoint in `survey-assist-api` that align with the existing SIC lookup pattern, so that SOC lookups can be exercised end‑to‑end against a small, packaged example dataset from `soc-classification-library` without relying on external SOC index configuration.

> **CI note:** GitHub Actions currently fails during `make install-dev` because `pyproject.toml` in `survey-assist-api` points to local path dependencies (for `sic-classification-utils`, `soc-classification-library`, and `soc-classification-utils`) that do not exist on the runner filesystem. This is expected - will be resolved once those dependencies are switched back to git URLs and a new `soc-classification-library` release is tagged.

This PR depends on https://github.com/ONSdigital/soc-classification-library/pull/47

## 📜 Changes Introduced

- **survey-assist-api**: SOC lookup client and endpoint aligned with SIC pattern
- **soc-classification-library**: CSV‑first SOC lookup and packaged example dataset (covered in the separate library PR)
- **Documentation**: Notes on how to exercise the new SOC lookup behaviour end‑to‑end

Key changes in `survey-assist-api`:

- Added a `SOCLookupClient` under `api/services` that mirrors `SICLookupClient`:
- Introduced a `/soc-lookup` FastAPI endpoint (under `api/routes/v1`) that is structurally equivalent to `/sic-lookup`:
- Wired the SOC lookup client and endpoint into the FastAPI app initialisation:
- Added unit and integration tests mirroring SIC coverage
 
## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit** (no new issues introduced by these changes)
- [x] API and unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`) – _not applicable for this PR_
- [x] DocStrings follow Google‑style and are added/updated where behaviour changed
- [x] Documentation / task notes for SA‑559 have been updated where relevant

## 🔍 How to Test

### Prerequisites / local setup

- Repos checked out as siblings in the same parent directory:
  - `soc-classification-library`on SA-559/soc-lookup-client-pattern branch.
  - `soc-classification-vector-store`
  - `survey-assist-api`on SA-559/soc-lookup-client-pattern branch.
  - `soc-classification-utils`
- Local path dependencies must be set in each repo so that SA‑559 changes are tested together from local checkouts. Specifically:
  - In `survey-assist-api/pyproject.toml`:
    - `soc-classification-library = { path = "../soc-classification-library" }`
    - `soc-classification-utils = { path = "../soc-classification-utils" }`
  - In `soc-classification-utils/pyproject.toml`:
    - `soc-classification-library = { path = "../soc-classification-library" }`
  - In `soc-classification-vector-store/pyproject.toml`:
    - `soc-classification-utils = { path = "../soc-classification-utils" }`
- Dependencies installed in each repo:

```bash
poetry install
```

- SOC vector store and Survey Assist API running locally (e.g. via your usual `make` / `poetry run` commands).

### API tests (unit and integration)

From the `survey-assist-api` root:

- Run the Python test suite:

```bash
poetry run pytest
```

This should exercise:

- SOC lookup client tests (mirroring `test_sic_lookup_client`) – initialisation, example vs custom paths, lookup/similarity behaviour, logging.
- `/soc-lookup` endpoint tests – 400/404 handling and 200 responses for exact and similarity‑based lookups, asserting that the JSON shape matches the SIC pattern with SOC‑appropriate fields.

### Lookup verification

With the API and SOC vector store running, from `survey-assist-api` root:

- Verify SOC lookup endpoint behaviour:

```bash
curl -i "http://0.0.0.0:8080/v1/survey-assist/soc-lookup?description=chief%20executives%20and%20senior%20officials&similarity=false"

curl -i "http://0.0.0.0:8080/v1/survey-assist/soc-lookup?description=senior%20officials&similarity=true"
```

Expected responses:

```http
HTTP/1.1 200 OK
content-type: application/json
content-length: 138

{"description":"chief executives and senior officials","code":"1111","code_meta":null,"code_major_group":"1","code_major_group_meta":null}
```

```http
HTTP/1.1 200 OK
content-type: application/json
content-length: 292

{"description":"senior officials","code":null,"code_meta":null,"code_major_group":null,"code_major_group_meta":null,"potential_matches":{"descriptions_count":1,"descriptions":["chief executives and senior officials"],"codes_count":1,"codes":["1111"],"major_groups_count":1,"major_groups":[]}}
```

### Smoke tests to check no regression classification occurs 

### SOC rephrase classification check

SOC classification endpoint with rephrase on/off:

```bash
curl -i -X POST "http://0.0.0.0:8080/v1/survey-assist/classify" \
  -H "Content-Type: application/json" \
  -d '{
    "llm": "gemini",
    "type": "soc",
    "job_title": "Chief executive",
    "job_description": "Leads the overall direction and strategy of a large organisation",
    "org_description": "Large national company",
    "options": { "soc": { "rephrased": true } }
  }'

curl -i -X POST "http://0.0.0.0:8080/v1/survey-assist/classify" \
  -H "Content-Type: application/json" \
  -d '{
    "llm": "gemini",
    "type": "soc",
    "job_title": "Chief executive",
    "job_description": "Leads the overall direction and strategy of a large organisation",
    "org_description": "Large national company",
    "options": { "soc": { "rephrased": false } }
  }'
```

Expected responses:

```http
HTTP/1.1 200 OK
content-type: application/json
content-length: 1508

{"requested_type":"soc","results":[{"type":"soc","classified":false,"followup":"Could you please specify the sector or industry in which the 'large national company' operates? For example, is it in government, a private enterprise, or a non-profit organisation?","code":null,"description":null,"candidates":[{"code":"1111","descriptive":"Senior officials and managers","likelihood":0.9},{"code":"2439","descriptive":"Business, research and administrative professionals n.e.c.","likelihood":0.6},{"code":"1139","descriptive":"Functional managers and directors n.e.c.","likelihood":0.3}],"reasoning":"The job title 'Chief executive' and description 'Leads the overall direction and strategy of a large organisation' strongly align with SOC code 1111 'Chief executives and senior officials'. However, the example job title 'Chief executive officer (government)' under SOC code 2439 suggests that the specific sector of the 'large national company' could influence the precise classification. Without knowing the sector (e.g., government, private, non-profit), it's difficult to definitively rule out 2439 or confirm 1111 with absolute certainty. SOC code 1139 is less likely as it refers to functional managers rather than the overall chief executive role described. SOC codes 3549 and 3552 are not relevant as they describe associate professionals and sales executives, which do not match the provided job title and description."}],"meta":{"llm":"gemini","applied_options":{"sic":{},"soc":{"rephrased":true}}}}
```

```http
HTTP/1.1 200 OK
content-type: application/json
content-length: 1517

{"requested_type":"soc","results":[{"type":"soc","classified":false,"followup":"Could you please specify the sector or industry in which the 'large national company' operates? For example, is it in government, a private enterprise, or a non-profit organisation?","code":null,"description":null,"candidates":[{"code":"1111","descriptive":"Chief executives and senior officials","likelihood":0.9},{"code":"2439","descriptive":"Business, research and administrative professionals n.e.c.","likelihood":0.6},{"code":"1139","descriptive":"Functional managers and directors n.e.c.","likelihood":0.3}],"reasoning":"The job title 'Chief executive' and description 'Leads the overall direction and strategy of a large organisation' strongly align with SOC code 1111 'Chief executives and senior officials'. However, the example job title 'Chief executive officer (government)' under SOC code 2439 suggests that the specific sector of the 'large national company' could influence the precise classification. Without knowing the sector (e.g., government, private, non-profit), it's difficult to definitively rule out 2439 or confirm 1111 with absolute certainty. SOC code 1139 is less likely as it refers to functional managers rather than the overall chief executive role described. SOC codes 3549 and 3552 are not relevant as they describe associate professionals and sales executives, which do not match the provided job title and description."}],"meta":{"llm":"gemini","applied_options":{"sic":{},"soc":{"rephrased":false}}}}
```

Both requests should return 200 with the same candidate set centred on SOC `1111`, and differ only in the `meta.applied_options.soc.rephrased` flag, confirming that the new SOC lookup wiring co‑exists cleanly with existing SOC classification flows.

### Combined SIC+SOC request



- **Combined SIC + SOC classification (`type="sic_soc"`)**

```bash
curl -i -X POST "http://0.0.0.0:8080/v1/survey-assist/classify" \
  -H "Content-Type: application/json" \
  -d '{
    "llm": "gemini",
    "type": "sic_soc",
    "job_title": "Farmer",
    "job_description": "Growing cereals and crops",
    "org_description": "Agricultural farm",
    "options": {
      "sic": { "rephrased": true },
      "soc": { "rephrased": false }
    }
  }'
```

Expected response:

```http
HTTP/1.1 200 OK
content-type: application/json
content-length: 2501

{"requested_type":"sic_soc","results":[{"type":"sic","classified":true,"followup":null,"code":"01110","description":"Growing of cereals (except rice), leguminous crops and oil seeds","candidates":[{"code":"01110","descriptive":"Crop growing","likelihood":0.99},{"code":"01410","descriptive":"Dairy farming","likelihood":0.1},{"code":"77390","descriptive":"Renting and leasing of other machinery, equipment and tangible goods nec","likelihood":0.1},{"code":"28301","descriptive":"Manufacture of agricultural tractors","likelihood":0.1},{"code":"01450","descriptive":"Sheep and goat farming","likelihood":0.1}],"reasoning":"The respondent data clearly states 'Agricultural farm' as the company's main activity, 'Farmer' as the job title, and 'Growing cereals and crops' as the job description. SIC code 01110, 'Growing of cereals (except rice), leguminous crops and oil seeds', directly aligns with the job description of 'Growing cereals and crops' and the general context of an 'Agricultural farm'. The example activities for 01110, such as 'Cereal grains growing, except rice' and 'Wheat growing', further reinforce this match. The other candidate codes are clearly unrelated to growing cereals and crops: 01410 and 01450 relate to animal farming, 77390 to renting machinery, and 28301 to manufacturing tractors. Therefore, 01110 can be assigned with high confidence."},{"type":"soc","classified":false,"followup":"Does the farmer own or manage the farm, or are they primarily involved in the day-to-day manual work of growing crops?","code":null,"description":null,"candidates":[{"code":"5111","descriptive":"Farmers","likelihood":0.9},{"code":"1211","descriptive":"Managers and proprietors in agriculture and horticulture","likelihood":0.7},{"code":"9111","descriptive":"Farm workers","likelihood":0.3}],"reasoning":"The job title 'Farmer' and job description 'Growing cereals and crops' strongly suggest SOC 5111 'Farmers'. However, depending on whether the individual owns/manages the farm or is primarily a worker, other codes like 1211 'Managers and proprietors in agriculture and horticulture' or 9111 'Farm workers' could also be relevant. The current information doesn't definitively distinguish between these roles, hence a follow-up question is needed. The two-digit code '51' is a strong candidate as it covers 'Agricultural and related trades', which aligns with the provided information."}],"meta":{"llm":"gemini","applied_options":{"sic":{"rephrased":true},"soc":{"rephrased":false}}}}
```