### PR TITLE
remove setting of env vars already done in the Terraform

### DIFF
--- a/cicd/cloudbuild_dev_and_sandbox.yaml
+++ b/cicd/cloudbuild_dev_and_sandbox.yaml
@@ -25,15 +25,6 @@ steps:
         gsutil cp $_SOC_REPHRASE_CSV data/
         ls data
 
-        SIC_LOOKUP_BASENAME="$(basename "$_SIC_LOOKUP_CSV")"
-        SIC_REPHRASE_BASENAME="$(basename "$_SIC_REPHRASE_CSV")"
-        SOC_LOOKUP_BASENAME="$(basename "$_SOC_LOOKUP_CSV")"
-        SOC_REPHRASE_BASENAME="$(basename "$_SOC_REPHRASE_CSV")"
-        echo "Using SIC lookup CSV: data/${SIC_LOOKUP_BASENAME}"
-        echo "Using SIC rephrase CSV: data/${SIC_REPHRASE_BASENAME}"
-        echo "Using SOC lookup CSV: data/${SOC_LOOKUP_BASENAME}"
-        echo "Using SOC rephrase CSV: data/${SOC_REPHRASE_BASENAME}"
-
         docker build -t $_GAR_IMAGE:$SHORT_SHA -t $_GAR_IMAGE:latest .
 
         docker push $_GAR_IMAGE:latest


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary
Extension of https://github.com/ONSdigital/survey-assist-api/pull/55

Fix dev Cloud Build deploy to Cloud Run by ensuring SOC lookup/rephrase CSVs are included in the image and the service is configured to read them.

## 📜 Changes Introduced

- [x] bug fix (fix:)
- [ ] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

- Run the `dev-api-cicd-push` Cloud Build trigger. It's the pipeline/job that was failing
- Confirm the new Cloud Run revision starts successfully and SOC data loads from `data/...` i.e. you don't see “Rephrased SOC data file not found”.
