### PR TITLE
SA-623/soc index and struct mandatory startup

### DIFF
--- a/cicd/cloudbuild_dev_and_sandbox.yaml
+++ b/cicd/cloudbuild_dev_and_sandbox.yaml
@@ -23,6 +23,9 @@ steps:
         gsutil cp $_SIC_REPHRASE_CSV data/
         gsutil cp $_SOC_LOOKUP_CSV data/
         gsutil cp $_SOC_REPHRASE_CSV data/
+        mkdir -p data/soc_index
+        gsutil cp $_SOC_INDEX_XLSX data/soc_index/
+        gsutil cp $_SOC_STRUCTURE_XLSX data/soc_index/
         ls data
 
         docker build -t $_GAR_IMAGE:$SHORT_SHA -t $_GAR_IMAGE:latest .

--- a/docs/generic_classification.md
+++ b/docs/generic_classification.md
@@ -25,7 +25,7 @@ The classification process works as follows:
 
 ### SIC and SOC Data Sources
 
-To avoid ambiguity, SIC and SOC are not currently wired identically for startup data validation:
+SIC and SOC are not currently configured identically for startup data validation:
 
 - **SIC runtime data in this API**
   - Lookup data: SIC CSV knowledge base (`SIC_LOOKUP_DATA_PATH`, typically `data/sic_knowledge_base_utf8.csv`)

--- a/docs/generic_classification.md
+++ b/docs/generic_classification.md
@@ -23,6 +23,27 @@ The classification process works as follows:
 - **SIC Classification**: Fully implemented with vector store search, LLM classification, and rephrasing support.
 - **SOC Classification**: Implemented as a single-step RAG flow using the SOC vector store and a SOC LLM (when configured), with optional SOC rephrasing backed by `soc-classification-library`.
 
+### SIC and SOC Data Sources
+
+To avoid ambiguity, SIC and SOC are not currently wired identically for startup data validation:
+
+- **SIC runtime data in this API**
+  - Lookup data: SIC CSV knowledge base (`SIC_LOOKUP_DATA_PATH`, typically `data/sic_knowledge_base_utf8.csv`)
+  - Rephrase data: SIC CSV rephrase dataset (`SIC_REPHRASE_DATA_PATH`)
+
+- **SOC runtime data in this API**
+  - Lookup data: SOC CSV lookup dataset (`SOC_LOOKUP_DATA_PATH`)
+  - Rephrase data: SOC CSV rephrase dataset (`SOC_REPHRASE_DATA_PATH`)
+  - Additional required SOC config data in `soc-classification-library`:
+    - `soc_index` (SOC Volume 2 coding index workbook)
+    - `soc_structure` (SOC Volume 1 structure/metadata workbook)
+
+**In practical terms:**
+
+- `soc_index` supports title/code lookup preparation from official SOC index content.
+- `soc_structure` provides SOC hierarchy/metadata used to enrich SOC responses.
+- Startup currently validates that both `soc_index` and `soc_structure` paths resolve.
+
 ## Endpoints
 
 ### Generic Classification Endpoint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ google-auth = "^2.28.0"
 fastapi_swagger2 = "^0.2.4"
 sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.3"}
 sic-classification-utils = {git = "https://github.com/ONSdigital/sic-classification-utils.git", tag = "v0.1.9"}
-soc-classification-library = { git = "https://github.com/ONSdigital/soc-classification-library.git", tag = "v0.1.4" }
+soc-classification-library = { git = "https://github.com/ONSdigital/soc-classification-library.git", tag = "v0.1.5" }
 soc-classification-utils = { git = "https://github.com/ONSdigital/soc-classification-utils.git" }
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.7"}
 firebase-admin = "^6.5.0"


### PR DESCRIPTION
# 📌 Pull Request – SA-633 SOC mandatory startup data fix

## ✨ Summary

This PR updates API build and runtime configuration so mandatory SOC startup files (`soc_index`, `soc_structure`) are available in Cloud Run and path resolution matches the container layout.

Depends on https://github.com/ONSdigital/soc-classification-library/pull/48 and https://github.com/ONSdigital/soc-classification-utils/pull/19 being approved

## 📜 Changes Introduced

- [x] Configuration / CI update
- [x] Documentation updates
- [ ] Terraform changes (if applicable)

- Updated `cicd/cloudbuild_dev_and_sandbox.yaml` to copy SOC Volume 1/2 workbook files into `data/soc_index/` before Docker build.
- Updated `pyproject.toml` to consume `soc-classification-library` release tag `v0.1.5`.
- Added SOC/SIC runtime data-source distinction in `docs/generic_classification.md` for clarity.


> **Current CI status**
>
> Lint fails because because this PR  pins `soc-classification-library` to `v0.1.5`, which has not yet been released. 



## ✅ Checklist

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

1. Ensure Cloud Build trigger substitutions are set:
   - `_SOC_INDEX_XLSX`
   - `_SOC_STRUCTURE_XLSX`
2. Run `dev-api-cicd-push` for the branch/main as appropriate.
3. Confirm Cloud Build succeeds and deploy completes.
4. Check Cloud Run logs for startup success (no missing `soc_index`/`soc_structure` errors).
