### PR TITLE
SA-649/align soc library data loading with sic

### DIFF
--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -685,29 +685,27 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
             reasoning=getattr(llm_response, "reasoning", "") or "",
         )
 
-        if (
+        # Mirror SIC behaviour - rephrasing defaults to enabled unless explicitly false.
+        soc_rephrase_client = getattr(request.app.state, "soc_rephrase_client", None)
+        if soc_rephrase_client and (result.code or result.candidates):
+            result = _apply_soc_rephrasing(
+                result, soc_rephrase_client, classification_request
+            )
+            logger.info(
+                "SOC rephrasing applied",
+                body_id=body_id,
+                has_rephrase_client=str(soc_rephrase_client is not None),
+                rephrased_candidates_count=str(len(result.candidates or [])),
+            )
+        elif (
             classification_request.options
             and classification_request.options.soc
             and classification_request.options.soc.rephrased
         ):
-            soc_rephrase_client = getattr(
-                request.app.state, "soc_rephrase_client", None
+            logger.info(
+                "SOC rephrasing requested but SOCRephraseClient not available",
+                body_id=body_id,
             )
-            if isinstance(soc_rephrase_client, SOCRephraseClient):
-                result = _apply_soc_rephrasing(
-                    result, soc_rephrase_client, classification_request
-                )
-                logger.info(
-                    "SOC rephrasing applied",
-                    body_id=body_id,
-                    has_rephrase_client=str(soc_rephrase_client is not None),
-                    rephrased_candidates_count=str(len(result.candidates or [])),
-                )
-            else:
-                logger.info(
-                    "SOC rephrasing requested but SOCRephraseClient not available",
-                    body_id=body_id,
-                )
 
         return result
 

--- a/api/services/soc_rephrase_client.py
+++ b/api/services/soc_rephrase_client.py
@@ -1,24 +1,28 @@
-"""SOC rephrase client for the Survey Assist API.
+"""SOC rephrase client service for the Survey Assist API.
 
-This client mirrors the behaviour of the SIC rephrase client, but for SOC:
-it loads a packaged SOC rephrase dataset and provides helpers to look up
-respondent-friendly descriptions by `soc_code` and to post-process SOC
-classification responses.
+This module provides a client for the SOC rephrase service, which maps
+standard SOC descriptions to user-friendly rephrased versions.
 """
 
+import logging
 from typing import Any, Optional
 
 import pandas as pd
 from fastapi import HTTPException
-from survey_assist_utils.logging import get_logger
 
 from api.services.package_utils import resolve_package_data_path
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 # CSV column names in the SOC rephrase dataset
 SOC_CODE_COL = "soc_code"
 REPHRASED_DESCRIPTION_COL = "rephrased_description"
+SOC_CODE_ALIASES = ("soc_code", "code", "soc")
+REPHRASED_DESCRIPTION_ALIASES = (
+    "rephrased_description",
+    "description_rephrased",
+    "rephrased",
+)
 
 
 class SOCRephraseClient:
@@ -31,19 +35,21 @@ class SOCRephraseClient:
             data_path: Optional path to the rephrased SOC dataset. When not
                 provided, uses the example dataset from soc-classification-library.
         """
-        resolved_path: Any = (
-            self._get_default_path() if data_path is None else data_path
-        )
-        if not isinstance(resolved_path, str):
-            raise ValueError("Data path must be a string")
-
-        self.rephrased_descriptions = self._load_rephrase_data(resolved_path)
+        source_path = self._resolve_data_path(data_path)
+        self.rephrased_descriptions = self._load_rephrase_data(source_path)
 
         logger.info(
-            "SOC rephrase client initialised",
-            data_path=resolved_path,
-            rephrased_count=str(self.get_rephrased_count()),
+            "SOC rephrase data loaded from %s (%d descriptions available)",
+            source_path,
+            self.get_rephrased_count(),
         )
+
+    def _resolve_data_path(self, data_path: Optional[str]) -> str:
+        """Resolve and validate the SOC rephrase source path."""
+        resolved = self._get_default_path() if data_path is None else data_path
+        if not isinstance(resolved, str):
+            raise ValueError("Data path must be a string")
+        return resolved
 
     def _get_default_path(self) -> str:
         """Get the default path to the rephrased SOC data file."""
@@ -65,44 +71,44 @@ class SOCRephraseClient:
             HTTPException: If the file is not found or has invalid format.
         """
         try:
-            df = pd.read_csv(data_path, dtype={SOC_CODE_COL: str})
-
-            required_columns = [SOC_CODE_COL, REPHRASED_DESCRIPTION_COL]
-            if not all(col in df.columns for col in required_columns):
-                raise ValueError(f"CSV file must contain columns: {required_columns}")
+            df = pd.read_csv(data_path)
+            code_col = self._find_column(df, SOC_CODE_ALIASES)
+            rephrased_col = self._find_column(df, REPHRASED_DESCRIPTION_ALIASES)
 
             rephrased_dict: dict[str, str] = {}
             for _, row in df.iterrows():
-                soc_code = str(row[SOC_CODE_COL]).strip()
-                rephrased_description = str(row[REPHRASED_DESCRIPTION_COL]).strip()
+                soc_code = str(row[code_col]).strip()
+                rephrased_description = str(row[rephrased_col]).strip()
                 if soc_code and rephrased_description:
                     rephrased_dict[soc_code] = rephrased_description
 
             logger.info(
-                "Loaded rephrased SOC descriptions",
-                rephrased_count=str(len(rephrased_dict)),
-                data_path=data_path,
+                "Loaded %d rephrased SOC descriptions from %s",
+                len(rephrased_dict),
+                data_path,
             )
             return rephrased_dict
         except FileNotFoundError:
-            logger.error(
-                "Rephrased SOC data file not found",
-                data_path=data_path,
-            )
+            logger.error("Rephrased SOC data file not found: %s", data_path)
             raise HTTPException(
                 status_code=500,
                 detail=f"Rephrased SOC data file not found: {data_path}",
             ) from None
         except Exception as exc:  # pylint: disable=broad-except
-            logger.error(
-                "Error loading rephrased SOC data",
-                data_path=data_path,
-                error=str(exc),
-            )
+            logger.error("Error loading rephrased SOC data from %s: %s", data_path, exc)
             raise HTTPException(
                 status_code=500,
                 detail=f"Error loading rephrased SOC data: {exc}",
             ) from exc
+
+    @staticmethod
+    def _find_column(dataframe: pd.DataFrame, aliases: tuple[str, ...]) -> str:
+        """Return the first matching column name from a list of aliases."""
+        columns_map = {str(col).strip().lower(): str(col) for col in dataframe.columns}
+        for alias in aliases:
+            if alias in columns_map:
+                return columns_map[alias]
+        raise ValueError(f"CSV file must contain one of columns: {aliases}")
 
     def get_rephrased_description(self, soc_code: str) -> Optional[str]:
         """Get the rephrased description for a given SOC code, if available."""

--- a/poetry.lock
+++ b/poetry.lock
@@ -7544,26 +7544,23 @@ files = [
 
 [[package]]
 name = "soc-classification-library"
-version = "0.1.4"
+version = "0.1.5"
 description = "Standard Occupational Classification library"
 optional = false
 python-versions = "^3.12"
 groups = ["main"]
 files = []
-develop = false
+develop = true
 
 [package.dependencies]
-openpyxl = "^3.0.0"
 pandas = "^2.3.0"
 pydantic = "^2.11.7"
 pyprojroot = "^0.3.0"
 toml = "^0.10.2"
 
 [package.source]
-type = "git"
-url = "https://github.com/ONSdigital/soc-classification-library.git"
-reference = "v0.1.4"
-resolved_reference = "c920e74754b027bd5e59e93eb9be5e0088368f4b"
+type = "directory"
+url = "../soc-classification-library"
 
 [[package]]
 name = "soc-classification-utils"
@@ -7573,7 +7570,7 @@ optional = false
 python-versions = "^3.12"
 groups = ["main"]
 files = []
-develop = false
+develop = true
 
 [package.dependencies]
 autocorrect = "^2.6.1"
@@ -7592,16 +7589,14 @@ pandas = "^2.3.0"
 posthog = ">=2.4.0,<6.0.0"
 pydantic = "^2.11.1"
 sentence-transformers = "4.1.0"
-soc-classification-library = {git = "https://github.com/ONSdigital/soc-classification-library.git", tag = "v0.1.4"}
+soc-classification-library = {path = "../soc-classification-library", develop = true}
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.7"}
 torch = "2.7.1"
 transformers = "4.48.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/ONSdigital/soc-classification-utils.git"
-reference = "HEAD"
-resolved_reference = "7b53e5a99a2602b2706e66a574531370204abeac"
+type = "directory"
+url = "../soc-classification-utils"
 
 [[package]]
 name = "sqlalchemy"
@@ -8972,4 +8967,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "75ca7c9b28b4186107a7ae9371823722780cc8566654c0f5545f8c79ea41b382"
+content-hash = "86695b3c6688b24e504abb036bd136fabf6563463a52be7156d3f66685f8e6c9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ google-auth = "^2.28.0"
 fastapi_swagger2 = "^0.2.4"
 sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.3"}
 sic-classification-utils = {git = "https://github.com/ONSdigital/sic-classification-utils.git", tag = "v0.1.9"}
-soc-classification-library = { git = "https://github.com/ONSdigital/soc-classification-library.git", tag = "v0.1.4" }
-soc-classification-utils = { git = "https://github.com/ONSdigital/soc-classification-utils.git" }
+soc-classification-library = {path = "../soc-classification-library", develop = true}
+soc-classification-utils = {path = "../soc-classification-utils", develop = true}
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.7"}
 firebase-admin = "^6.5.0"
 

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -962,7 +962,7 @@ def test_classify_endpoint_meta_field_exclusion(
 
 
 @patch(
-    "occupational_classification_utils.utils.soc_data_access.pd.read_excel",
+    "occupational_classification.data_access.soc_data_access.pd.read_excel",
     side_effect=AssertionError("SOC classify must not use Excel loaders"),
 )
 @patch("api.routes.v1.classify.SOCVectorStoreClient")

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -27,6 +27,8 @@ Dependencies:
     - fastapi.status: Provides standard HTTP status codes for assertions.
 """
 
+# pylint: disable=too-many-lines
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -990,3 +992,114 @@ def test_soc_classify_does_not_require_excel(mock_soc_vector_store, _mock_read_e
     assert data["requested_type"] == "soc"
     assert len(data["results"]) == 1
     assert data["results"][0]["type"] == "soc"
+
+
+@patch("api.routes.v1.classify.SOCVectorStoreClient")
+@patch("api.main.app.state.soc_llm")
+def test_soc_classify_rephrases_by_default(mock_soc_llm, mock_soc_vector_store):
+    """SOC rephrasing defaults to enabled when options are omitted (mirrors SIC)."""
+    mock_soc_vector_store.return_value.search = AsyncMock(
+        return_value=[
+            {
+                "code": EXPECTED_SOC_CODE,
+                "title": EXPECTED_SOC_DESCRIPTION,
+                "distance": 0.05,
+            }
+        ]
+    )
+    mock_soc_llm.sa_rag_soc_code = AsyncMock(
+        return_value=(
+            MagicMock(
+                soc_code=EXPECTED_SOC_CODE,
+                soc_descriptive="Elementary occupations",
+                soc_candidates=[
+                    MagicMock(
+                        soc_code=EXPECTED_SOC_CODE,
+                        soc_descriptive="Elementary occupations",
+                        likelihood=EXPECTED_LIKELIHOOD,
+                    )
+                ],
+                followup=None,
+                reasoning="Mocked SOC reasoning",
+            ),
+            None,
+            None,
+        )
+    )
+    mock_soc_rephrase_client = MagicMock()
+    mock_soc_rephrase_client.get_rephrased_description.return_value = (
+        EXPECTED_SOC_DESCRIPTION
+    )
+    app.state.soc_rephrase_client = mock_soc_rephrase_client
+
+    request_data = {
+        "llm": "gemini",
+        "type": "soc",
+        "job_title": "Farm worker",
+        "job_description": "General labour work on a farm",
+        "org_description": "Agricultural business",
+    }
+
+    response = client.post("/v1/survey-assist/classify", json=request_data)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    first = data["results"][0]
+    assert first["description"] == EXPECTED_SOC_DESCRIPTION
+    assert first["candidates"][0]["descriptive"] == EXPECTED_SOC_DESCRIPTION
+
+
+@patch("api.routes.v1.classify.SOCVectorStoreClient")
+@patch("api.main.app.state.soc_llm")
+def test_soc_classify_rephrased_false_keeps_original_descriptions(
+    mock_soc_llm, mock_soc_vector_store
+):
+    """SOC rephrasing remains disabled when explicitly set to false."""
+    mock_soc_vector_store.return_value.search = AsyncMock(
+        return_value=[
+            {
+                "code": EXPECTED_SOC_CODE,
+                "title": EXPECTED_SOC_DESCRIPTION,
+                "distance": 0.05,
+            }
+        ]
+    )
+    mock_soc_llm.sa_rag_soc_code = AsyncMock(
+        return_value=(
+            MagicMock(
+                soc_code=EXPECTED_SOC_CODE,
+                soc_descriptive="Elementary occupations",
+                soc_candidates=[
+                    MagicMock(
+                        soc_code=EXPECTED_SOC_CODE,
+                        soc_descriptive="Elementary occupations",
+                        likelihood=EXPECTED_LIKELIHOOD,
+                    )
+                ],
+                followup=None,
+                reasoning="Mocked SOC reasoning",
+            ),
+            None,
+            None,
+        )
+    )
+    mock_soc_rephrase_client = MagicMock()
+    mock_soc_rephrase_client.get_rephrased_description.return_value = (
+        EXPECTED_SOC_DESCRIPTION
+    )
+    app.state.soc_rephrase_client = mock_soc_rephrase_client
+
+    request_data = {
+        "llm": "gemini",
+        "type": "soc",
+        "job_title": "Farm worker",
+        "job_description": "General labour work on a farm",
+        "org_description": "Agricultural business",
+        "options": {"soc": {"rephrased": False}},
+    }
+
+    response = client.post("/v1/survey-assist/classify", json=request_data)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    first = data["results"][0]
+    assert first["description"] == "Elementary occupations"
+    assert first["candidates"][0]["descriptive"] == "Elementary occupations"

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -957,3 +957,36 @@ def test_classify_endpoint_meta_field_exclusion(
     # Verify that meta field is present in the response when options are provided
     assert "meta" in data
     assert data["meta"] is not None
+
+
+@patch(
+    "occupational_classification_utils.utils.soc_data_access.pd.read_excel",
+    side_effect=AssertionError("SOC classify must not use Excel loaders"),
+)
+@patch("api.routes.v1.classify.SOCVectorStoreClient")
+def test_soc_classify_does_not_require_excel(mock_soc_vector_store, _mock_read_excel):
+    """SOC classify works even when Excel loaders are unavailable."""
+    mock_soc_vector_store.return_value.search = AsyncMock(
+        return_value=[
+            {
+                "code": EXPECTED_SOC_CODE,
+                "title": EXPECTED_SOC_DESCRIPTION,
+                "distance": 0.05,
+            }
+        ]
+    )
+
+    request_data = {
+        "llm": "gemini",
+        "type": "soc",
+        "job_title": "Farm worker",
+        "job_description": "General labour work on a farm",
+        "org_description": "Agricultural business",
+    }
+
+    response = client.post("/v1/survey-assist/classify", json=request_data)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["requested_type"] == "soc"
+    assert len(data["results"]) == 1
+    assert data["results"][0]["type"] == "soc"

--- a/tests/test_soc_rephrase_client.py
+++ b/tests/test_soc_rephrase_client.py
@@ -33,7 +33,7 @@ class TestSOCRephraseClient:
 
             SOCRephraseClient(data_path=custom_path)
 
-            mock_read_csv.assert_called_once_with(custom_path, dtype={"soc_code": str})
+            mock_read_csv.assert_called_once_with(custom_path)
 
     def test_init_with_config_path(self):
         """Initialisation using package data path (via resolve_package_data_path)."""
@@ -68,7 +68,6 @@ class TestSOCRephraseClient:
             SOCRephraseClient()
 
             mock_read_csv.assert_called_once()
-            assert mock_read_csv.call_args[1]["dtype"] == {"soc_code": str}
             call_path = mock_read_csv.call_args[0][0]
             assert "/package/path/example_rephrased_soc_data.csv" in call_path
             mock_resolve.assert_called_once_with(
@@ -98,7 +97,7 @@ class TestSOCRephraseClient:
     @pytest.mark.parametrize(
         ("setup_kind", "expected_message_fragment"),
         [
-            ("missing_columns", "CSV file must contain columns"),
+            ("missing_columns", "CSV file must contain one of columns"),
             ("file_not_found", "Rephrased SOC data file not found"),
         ],
     )
@@ -122,6 +121,27 @@ class TestSOCRephraseClient:
             expected_status_code = 500
             assert exc_info.value.status_code == expected_status_code
             assert expected_message_fragment in str(exc_info.value.detail)
+
+    def test_load_rephrase_data_supports_column_aliases(self):
+        """Loading supports alternate but equivalent CSV column names."""
+        test_data = [
+            {
+                "code": "1139",
+                "description_rephrased": "Functional managers other roles",
+            },
+        ]
+
+        with patch("pandas.read_csv") as mock_read_csv:
+            mock_df = mock_read_csv.return_value
+            mock_df.columns = ["code", "description_rephrased"]
+            mock_df.iterrows.return_value = list(enumerate(test_data))
+
+            client = SOCRephraseClient()
+
+            assert (
+                client.get_rephrased_description("1139")
+                == "Functional managers other roles"
+            )
 
     def test_get_rephrased_description(self):
         """Get rephrased description for a SOC code."""


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

<!-- Provide a short, clear summary of what this PR does. Keep it concise but informative. -->
Aligns SOC classify rephrase behaviour with SIC by enabling SOC rephrasing by default when options are omitted, while preserving explicit opt-out via `options.soc.rephrased=false`. Adds regression tests to lock this behaviour and keep parity between SIC and SOC classify paths.

> **Note**
> CI may fail for this branch while local path dependency is in place for cross-repo SA-649 verification.

> **Related repos and PRs for end-to-end verification**
> This branch is expected to be exercised together with the following pull requests when validating SOC paths locally or in a linked workspace.
>
> - [soc-classification-utils PR 21](https://github.com/ONSdigital/soc-classification-utils/pull/21)
> - [soc-classification-library PR 50](https://github.com/ONSdigital/soc-classification-library/pull/50)
> - [soc-classification-vector-store PR 12](https://github.com/ONSdigital/soc-classification-vector-store/pull/12)

## 📜 Changes Introduced

<!-- List key changes made in this PR. Consider bullet points for readability. -->
- Updated SOC classify rephrasing flow in `api/routes/v1/classify.py` to mirror SIC default semantics:
  - default rephrase enabled when options are omitted
  - explicit `options.soc.rephrased=false` keeps original non-rephrased candidate text
- Kept SOC rephrase application on the existing `_apply_soc_rephrasing(...)` helper path for consistency.
- Added SOC classify regression tests in `tests/test_classify.py`:
  - verifies default SOC rephrase is applied
  - verifies explicit `rephrased=false` disables rephrase
- Added module-level pylint suppression for `too-many-lines` in `tests/test_classify.py` to satisfy `make check-python`.

- [x] Feature implementation (feat:) / bug fix (fix:) / refactoring (chore:) / documentation (docs:) / testing (test:)
- [x] Updates to tests and/or documentation
- [x] Terraform changes (if applicable) - N/A (no Terraform changes in this PR)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [ ] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [x] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`) - N/A
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

<!-- Describe how reviewers can verify your changes. Include test commands if applicable. -->
From `survey-assist-api` repo root:

1. Run classify-focused tests
   - `poetry run pytest -q tests/test_classify.py`
   - Observed on this branch run: **13 passed**.

2. Run Python quality gate
   - `make check-python`
   - Observed on this branch run: **pass** (isort, black, ruff, mypy, pylint, bandit).

3. Manual API verification with key outputs
   - Ensure SIC + SOC vector stores and API are running.
   - Set dataset environment variables in the API shell before testing:

```bash
export SIC_LOOKUP_DATA_PATH="survey-assist-api/data/sic_knowledge_base_utf8.csv"
export SIC_REPHRASE_DATA_PATH="data/sic_rephrased_2025_02_03_v2"
export SOC_LOOKUP_DATA_PATH="survey-assist-api/data/soc_knowledge_base_utf8_SA-649.csv"
export SOC_REPHRASE_DATA_PATH="survey-assist-api/data/soc_rephrased_2026_04_17_nec_only.csv"
```

   - Run SOC classify without options:

```bash
curl -s -X POST "http://localhost:8080/v1/survey-assist/classify" \
  -H "Content-Type: application/json" \
  -d '{
    "llm": "gemini",
    "type": "soc",
    "job_title": "Construction and building trades other roles",
    "job_description": "Construction and building trades other roles",
    "org_description": "Construction and building trades other roles"
  }'
```

   - Run SOC classify with rephrase explicitly off:

```bash
curl -s -X POST "http://localhost:8080/v1/survey-assist/classify" \
  -H "Content-Type: application/json" \
  -d '{
    "llm": "gemini",
    "type": "soc",
    "job_title": "Construction and building trades other roles",
    "job_description": "Construction and building trades other roles",
    "org_description": "Construction and building trades other roles",
    "options": {
      "soc": {
        "rephrased": false
      }
    }
  }'
```

Observed key output on current running services:
- SOC classify (options omitted) -> HTTP **200**, top candidate `5319`, descriptive `Skilled trades occupations`.
- SOC classify (`options.soc.rephrased=false`) -> HTTP **200**, top candidate `5319`, descriptive `Skilled trades occupations`.
- SOC classify (`options.soc.rephrased=true`) -> HTTP **200**, top candidate `5319`, descriptive `Skilled trades occupations`.
- In this rerun, top candidate text remained unchanged across SOC rephrase toggles for the same payload.

4. SOC lookup integration checks
   - Run exact SOC lookup:

```bash
curl -s "http://localhost:8080/v1/survey-assist/soc-lookup?description=chief%20executives%20and%20senior%20officials&similarity=false"
```

   - Run similarity SOC lookup:

```bash
curl -s "http://localhost:8080/v1/survey-assist/soc-lookup?description=senior%20officials&similarity=true"
```

Observed key output on current running services:
- Exact lookup (`description=chief executives and senior officials&similarity=false`) -> HTTP **200**, `code: "1111"`, `description: "chief executives and senior officials"`.
- Similarity lookup (`description=senior officials&similarity=true`) -> HTTP **200**, `code: null`, `potential_matches.codes_count: 1`, first code `1111`.

4.1 SOC lookup metadata check
   - Reuse the exact SOC lookup call in step 4 and inspect metadata fields in the JSON response.

Observed metadata check:
- Exact lookup returned `code_meta.code: "1111"` and `code_major_group_meta.code: "1"` (distinct unit and major-group metadata present).
- `code_meta.group_title` resolved to `Chief executives and senior officials`.
- `code_major_group_meta.group_title` resolved to `Managers directors and senior officials`.


5. Combined SIC and SOC classify check
   - Run SIC classify:

```bash
curl -s -X POST "http://localhost:8080/v1/survey-assist/classify" \
  -H "Content-Type: application/json" \
  -d '{
    "llm": "gemini",
    "type": "sic",
    "job_title": "Electrician",
    "job_description": "Installs and maintains electrical wiring in buildings",
    "org_description": "Construction contractor"
  }'
```

Observed key output on current running services:
- SIC classify -> HTTP **200**, `results[0].type: "sic"`, `results[0].code: "43210"`, `results[0].description: "Electrical installation"`.
- SOC classify -> HTTP **200** (all variants above), with candidate output present and rephrase toggle reflected in SOC candidate descriptions.
