### PR TITLE
fix(sic): Enable compatibility with new rephrased label file

### DIFF
--- a/api/services/sic_rephrase_client.py
+++ b/api/services/sic_rephrase_client.py
@@ -77,7 +77,9 @@ class SICRephraseClient:
             )
 
             if description_column is None:
-                raise ValueError(f"CSV file must contain column: {description_columns[0]} or {description_columns[1]}")
+                raise ValueError(
+                    f"CSV file must contain column: {description_columns[0]} or {description_columns[1]}"
+                )
 
             # Create dictionary mapping SIC codes to rephrased descriptions
             rephrased_dict = {}
@@ -102,8 +104,12 @@ class SICRephraseClient:
                 detail=f"Rephrased SIC data file not found: {data_path}",
             ) from None
         except Exception as e:
-            logger.error("Error loading rephrased SIC data", data_path=data_path, error=str(e))
-            raise HTTPException(status_code=500, detail=f"Error loading rephrased SIC data: {e}") from e
+            logger.error(
+                "Error loading rephrased SIC data", data_path=data_path, error=str(e)
+            )
+            raise HTTPException(
+                status_code=500, detail=f"Error loading rephrased SIC data: {e}"
+            ) from e
 
     def _get_default_path(self) -> str:
         """Get the default path to the rephrased SIC data file.
@@ -112,7 +118,9 @@ class SICRephraseClient:
             str: Path to the rephrased Sic data file.
         """
         # Always use the example dataset from the package
-        return resolve_package_data_path("industrial_classification.data", "example_rephrased_sic_data.csv")
+        return resolve_package_data_path(
+            "industrial_classification.data", "example_rephrased_sic_data.csv"
+        )
 
     def get_rephrased_description(self, sic_code: str) -> Optional[str]:
         """Get the rephrased description for a given SIC code.
@@ -156,7 +164,9 @@ class SICRephraseClient:
         """
         return str(sic_code).strip() in self.rephrased_descriptions
 
-    def process_classification_response(self, response_data: dict[str, Any]) -> dict[str, Any]:
+    def process_classification_response(
+        self, response_data: dict[str, Any]
+    ) -> dict[str, Any]:
         """Process a classification response to include rephrased descriptions.
 
         Args:

--- a/api/services/sic_rephrase_client.py
+++ b/api/services/sic_rephrase_client.py
@@ -4,7 +4,6 @@ This module provides a client for the SIC rephrase service, which is used to
 map standard SIC descriptions to user-friendly rephrased versions.
 """
 
-import logging
 from typing import Any, Optional
 
 import pandas as pd
@@ -60,22 +59,34 @@ class SICRephraseClient:
             HTTPException: If the file is not found or has invalid format.
         """
         try:
-            # Load the CSV file, ensuring SIC codes are read as strings to preserve leading zeros
-            df = pd.read_csv(data_path, dtype={"sic_code": str})
+            sic_code_column = "sic_code"
+            description_columns = (
+                "rephrased_description",
+                "reviewed_description",
+            )
 
-            # Validate required columns
-            required_columns = ["sic_code", "reviewed_description"]
-            if not all(col in df.columns for col in required_columns):
-                raise ValueError(f"CSV file must contain columns: {required_columns}")
+            # Load the CSV file, ensuring SIC codes are read as strings to preserve leading zeros
+            df = pd.read_csv(data_path, dtype={sic_code_column: str})
+
+            if sic_code_column not in df.columns:
+                raise ValueError(f"CSV file must contain column: {sic_code_column}")
+
+            description_column = next(
+                (column for column in description_columns if column in df.columns),
+                None,
+            )
+
+            if description_column is None:
+                raise ValueError(f"CSV file must contain column: {description_columns[0]} or {description_columns[1]}")
 
             # Create dictionary mapping SIC codes to rephrased descriptions
             rephrased_dict = {}
             for _, row in df.iterrows():
-                sic_code = str(row["sic_code"]).strip()
-                reviewed_description = str(row["reviewed_description"]).strip()
+                sic_code = str(row[sic_code_column]).strip()
+                rephrased_description = str(row[description_column]).strip()
 
-                if sic_code and reviewed_description:
-                    rephrased_dict[sic_code] = reviewed_description
+                if sic_code and rephrased_description:
+                    rephrased_dict[sic_code] = rephrased_description
 
             logger.info(
                 "Loaded rephrased SIC descriptions",
@@ -101,9 +112,7 @@ class SICRephraseClient:
             str: Path to the rephrased Sic data file.
         """
         # Always use the example dataset from the package
-        return resolve_package_data_path(
-            "industrial_classification.data", "example_rephrased_sic_data.csv"
-        )
+        return resolve_package_data_path("industrial_classification.data", "example_rephrased_sic_data.csv")
 
     def get_rephrased_description(self, sic_code: str) -> Optional[str]:
         """Get the rephrased description for a given SIC code.
@@ -147,9 +156,7 @@ class SICRephraseClient:
         """
         return str(sic_code).strip() in self.rephrased_descriptions
 
-    def process_classification_response(
-        self, response_data: dict[str, Any]
-    ) -> dict[str, Any]:
+    def process_classification_response(self, response_data: dict[str, Any]) -> dict[str, Any]:
         """Process a classification response to include rephrased descriptions.
 
         Args:

--- a/api/services/sic_rephrase_client.py
+++ b/api/services/sic_rephrase_client.py
@@ -9,10 +9,11 @@ from typing import Any, Optional
 
 import pandas as pd
 from fastapi import HTTPException
+from survey_assist_utils.logging import get_logger
 
 from api.services.package_utils import resolve_package_data_path
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Constants
 FOUR_DIGIT_SIC_CODE = 4
@@ -41,9 +42,9 @@ class SICRephraseClient:
 
         # Log confirmation of data loading
         logger.info(
-            "SIC rephrase data loaded from %s (%d descriptions available)",
-            resolved_path,
-            self.get_rephrased_count(),
+            "SIC rephrase data loaded",
+            data_path=resolved_path,
+            descriptions_available=self.get_rephrased_count(),
         )
 
     def _load_rephrase_data(self, data_path: str) -> dict[str, str]:
@@ -77,23 +78,21 @@ class SICRephraseClient:
                     rephrased_dict[sic_code] = reviewed_description
 
             logger.info(
-                "Loaded %d rephrased SIC descriptions from %s",
-                len(rephrased_dict),
-                data_path,
+                "Loaded rephrased SIC descriptions",
+                rephrased_count=len(rephrased_dict),
+                data_path=data_path,
             )
             return rephrased_dict
 
         except FileNotFoundError:
-            logger.error("Rephrased SIC data file not found: %s", data_path)
+            logger.error("Rephrased SIC data file not found", data_path=data_path)
             raise HTTPException(
                 status_code=500,
                 detail=f"Rephrased SIC data file not found: {data_path}",
             ) from None
         except Exception as e:
-            logger.error("Error loading rephrased SIC data from %s: %s", data_path, e)
-            raise HTTPException(
-                status_code=500, detail=f"Error loading rephrased SIC data: {e}"
-            ) from e
+            logger.error("Error loading rephrased SIC data", data_path=data_path, error=str(e))
+            raise HTTPException(status_code=500, detail=f"Error loading rephrased SIC data: {e}") from e
 
     def _get_default_path(self) -> str:
         """Get the default path to the rephrased SIC data file.

--- a/api/services/sic_rephrase_client.py
+++ b/api/services/sic_rephrase_client.py
@@ -78,7 +78,8 @@ class SICRephraseClient:
 
             if description_column is None:
                 raise ValueError(
-                    f"CSV file must contain column: {description_columns[0]} or {description_columns[1]}"
+                    "CSV file must contain column: "
+                    f"{description_columns[0]} or {description_columns[1]}"
                 )
 
             # Create dictionary mapping SIC codes to rephrased descriptions

--- a/api/services/sic_rephrase_client.py
+++ b/api/services/sic_rephrase_client.py
@@ -4,7 +4,6 @@ This module provides a client for the SIC rephrase service, which is used to
 map standard SIC descriptions to user-friendly rephrased versions.
 """
 
-import logging
 from typing import Any, Optional
 
 import pandas as pd
@@ -64,7 +63,7 @@ class SICRephraseClient:
             df = pd.read_csv(data_path, dtype={"sic_code": str})
 
             # Validate required columns
-            required_columns = ["sic_code", "reviewed_description"]
+            required_columns = ["sic_code", "rephrased_description"]
             if not all(col in df.columns for col in required_columns):
                 raise ValueError(f"CSV file must contain columns: {required_columns}")
 
@@ -72,10 +71,10 @@ class SICRephraseClient:
             rephrased_dict = {}
             for _, row in df.iterrows():
                 sic_code = str(row["sic_code"]).strip()
-                reviewed_description = str(row["reviewed_description"]).strip()
+                rephrased_description = str(row["rephrased_description"]).strip()
 
-                if sic_code and reviewed_description:
-                    rephrased_dict[sic_code] = reviewed_description
+                if sic_code and rephrased_description:
+                    rephrased_dict[sic_code] = rephrased_description
 
             logger.info(
                 "Loaded rephrased SIC descriptions",
@@ -91,8 +90,12 @@ class SICRephraseClient:
                 detail=f"Rephrased SIC data file not found: {data_path}",
             ) from None
         except Exception as e:
-            logger.error("Error loading rephrased SIC data", data_path=data_path, error=str(e))
-            raise HTTPException(status_code=500, detail=f"Error loading rephrased SIC data: {e}") from e
+            logger.error(
+                "Error loading rephrased SIC data", data_path=data_path, error=str(e)
+            )
+            raise HTTPException(
+                status_code=500, detail=f"Error loading rephrased SIC data: {e}"
+            ) from e
 
     def _get_default_path(self) -> str:
         """Get the default path to the rephrased SIC data file.

--- a/api/services/sic_rephrase_client.py
+++ b/api/services/sic_rephrase_client.py
@@ -4,6 +4,7 @@ This module provides a client for the SIC rephrase service, which is used to
 map standard SIC descriptions to user-friendly rephrased versions.
 """
 
+import logging
 from typing import Any, Optional
 
 import pandas as pd
@@ -59,37 +60,22 @@ class SICRephraseClient:
             HTTPException: If the file is not found or has invalid format.
         """
         try:
-            sic_code_column = "sic_code"
-            description_columns = (
-                "rephrased_description",
-                "reviewed_description",
-            )
-
             # Load the CSV file, ensuring SIC codes are read as strings to preserve leading zeros
-            df = pd.read_csv(data_path, dtype={sic_code_column: str})
+            df = pd.read_csv(data_path, dtype={"sic_code": str})
 
-            if sic_code_column not in df.columns:
-                raise ValueError(f"CSV file must contain column: {sic_code_column}")
-
-            description_column = next(
-                (column for column in description_columns if column in df.columns),
-                None,
-            )
-
-            if description_column is None:
-                raise ValueError(
-                    "CSV file must contain column: "
-                    f"{description_columns[0]} or {description_columns[1]}"
-                )
+            # Validate required columns
+            required_columns = ["sic_code", "reviewed_description"]
+            if not all(col in df.columns for col in required_columns):
+                raise ValueError(f"CSV file must contain columns: {required_columns}")
 
             # Create dictionary mapping SIC codes to rephrased descriptions
             rephrased_dict = {}
             for _, row in df.iterrows():
-                sic_code = str(row[sic_code_column]).strip()
-                rephrased_description = str(row[description_column]).strip()
+                sic_code = str(row["sic_code"]).strip()
+                reviewed_description = str(row["reviewed_description"]).strip()
 
-                if sic_code and rephrased_description:
-                    rephrased_dict[sic_code] = rephrased_description
+                if sic_code and reviewed_description:
+                    rephrased_dict[sic_code] = reviewed_description
 
             logger.info(
                 "Loaded rephrased SIC descriptions",
@@ -105,12 +91,8 @@ class SICRephraseClient:
                 detail=f"Rephrased SIC data file not found: {data_path}",
             ) from None
         except Exception as e:
-            logger.error(
-                "Error loading rephrased SIC data", data_path=data_path, error=str(e)
-            )
-            raise HTTPException(
-                status_code=500, detail=f"Error loading rephrased SIC data: {e}"
-            ) from e
+            logger.error("Error loading rephrased SIC data", data_path=data_path, error=str(e))
+            raise HTTPException(status_code=500, detail=f"Error loading rephrased SIC data: {e}") from e
 
     def _get_default_path(self) -> str:
         """Get the default path to the rephrased SIC data file.

--- a/tests/test_sic_rephrase_client.py
+++ b/tests/test_sic_rephrase_client.py
@@ -14,13 +14,6 @@ logger = get_logger(__name__)
 class TestSICRephraseClient:
     """Test cases for the SIC rephrase client."""
 
-    def test_init_with_non_string_path(self):
-        """Test initialisation rejects non-string data paths."""
-        with pytest.raises(ValueError) as exc_info:
-            SICRephraseClient(data_path=123)
-
-        assert str(exc_info.value) == "Data path must be a string"
-
     def test_init_with_custom_path(self):
         """Test initialisation with a custom data path."""
         custom_path = "/custom/path/rephrased.csv"
@@ -39,12 +32,9 @@ class TestSICRephraseClient:
 
     def test_init_with_config_path(self):
         """Test initialisation using package data path (environment variables ignored)."""
-        with (
-            patch("pandas.read_csv") as mock_read_csv,
-            patch(
-                "api.services.sic_rephrase_client.resolve_package_data_path"
-            ) as mock_resolve,
-        ):
+        with patch("pandas.read_csv") as mock_read_csv, patch(
+            "api.services.sic_rephrase_client.resolve_package_data_path"
+        ) as mock_resolve:
             mock_resolve.return_value = "/package/path/example_rephrased_sic_data.csv"
             mock_df = mock_read_csv.return_value
             mock_df.columns = ["sic_code", "reviewed_description"]
@@ -62,12 +52,9 @@ class TestSICRephraseClient:
 
     def test_init_with_package_fallback(self):
         """Test initialisation using package data (environment variables ignored)."""
-        with (
-            patch("pandas.read_csv") as mock_read_csv,
-            patch(
-                "api.services.sic_rephrase_client.resolve_package_data_path"
-            ) as mock_resolve,
-        ):
+        with patch("pandas.read_csv") as mock_read_csv, patch(
+            "api.services.sic_rephrase_client.resolve_package_data_path"
+        ) as mock_resolve:
             mock_resolve.return_value = "/package/path/example_rephrased_sic_data.csv"
             mock_df = mock_read_csv.return_value
             mock_df.columns = ["sic_code", "reviewed_description"]
@@ -88,12 +75,9 @@ class TestSICRephraseClient:
 
     def test_init_with_sic_library_path(self):
         """Test initialisation using package data path (environment variables ignored)."""
-        with (
-            patch("pandas.read_csv") as mock_read_csv,
-            patch(
-                "api.services.sic_rephrase_client.resolve_package_data_path"
-            ) as mock_resolve,
-        ):
+        with patch("pandas.read_csv") as mock_read_csv, patch(
+            "api.services.sic_rephrase_client.resolve_package_data_path"
+        ) as mock_resolve:
             mock_resolve.return_value = "/package/path/example_rephrased_sic_data.csv"
             mock_df = mock_read_csv.return_value
             mock_df.columns = ["sic_code", "reviewed_description"]
@@ -133,25 +117,6 @@ class TestSICRephraseClient:
             expected_count = 3
             assert client.get_rephrased_count() == expected_count
 
-    def test_load_rephrase_data_success_with_rephrased_column(self):
-        """Test successful loading when using the current description column name."""
-        test_data = [
-            {"sic_code": "01120", "rephrased_description": "Rice farming"},
-            {"sic_code": "01110", "rephrased_description": "Cereal farming"},
-        ]
-
-        with patch("pandas.read_csv") as mock_read_csv:
-            mock_df = mock_read_csv.return_value
-            mock_df.columns = ["sic_code", "rephrased_description"]
-            mock_df.iterrows.return_value = list(enumerate(test_data))
-
-            client = SICRephraseClient()
-
-            assert client.get_rephrased_description("01120") == "Rice farming"
-            assert client.get_rephrased_description("01110") == "Cereal farming"
-            expected_count = 2
-            assert client.get_rephrased_count() == expected_count
-
     def test_load_rephrase_data_missing_columns(self):
         """Test loading data with missing required columns."""
         with patch("pandas.read_csv") as mock_read_csv:
@@ -159,31 +124,14 @@ class TestSICRephraseClient:
             mock_df.columns = [
                 "sic_code",
                 "wrong_column",
-            ]  # Missing rephrased_description and reviewed_description
+            ]  # Missing reviewed_description
 
             with pytest.raises(HTTPException) as exc_info:
                 SICRephraseClient()
 
             expected_status_code = 500
             assert exc_info.value.status_code == expected_status_code
-            assert "rephrased_description or reviewed_description" in str(
-                exc_info.value.detail
-            )
-
-    def test_load_rephrase_data_missing_sic_code_column(self):
-        """Test loading data with no sic_code column."""
-        with patch("pandas.read_csv") as mock_read_csv:
-            mock_df = mock_read_csv.return_value
-            mock_df.columns = ["rephrased_description"]
-
-            with pytest.raises(HTTPException) as exc_info:
-                SICRephraseClient()
-
-            expected_status_code = 500
-            assert exc_info.value.status_code == expected_status_code
-            assert "CSV file must contain column: sic_code" in str(
-                exc_info.value.detail
-            )
+            assert "CSV file must contain columns" in str(exc_info.value.detail)
 
     def test_load_rephrase_data_file_not_found(self):
         """Test handling of missing data file."""

--- a/tests/test_sic_rephrase_client.py
+++ b/tests/test_sic_rephrase_client.py
@@ -14,16 +14,23 @@ logger = get_logger(__name__)
 class TestSICRephraseClient:
     """Test cases for the SIC rephrase client."""
 
+    def test_init_with_non_string_path(self):
+        """Test initialisation rejects non-string data paths."""
+        with pytest.raises(ValueError) as exc_info:
+            SICRephraseClient(data_path=123)  # type: ignore
+
+        assert str(exc_info.value) == "Data path must be a string"
+
     def test_init_with_custom_path(self):
         """Test initialisation with a custom data path."""
         custom_path = "/custom/path/rephrased.csv"
 
         with patch("pandas.read_csv") as mock_read_csv:
             mock_df = mock_read_csv.return_value
-            mock_df.columns = ["sic_code", "reviewed_description"]
+            mock_df.columns = ["sic_code", "rephrased_description"]
             mock_df.iterrows.return_value = [
-                (0, {"sic_code": "01120", "reviewed_description": "Rice farming"}),
-                (1, {"sic_code": "01110", "reviewed_description": "Cereal farming"}),
+                (0, {"sic_code": "01120", "rephrased_description": "Rice farming"}),
+                (1, {"sic_code": "01110", "rephrased_description": "Cereal farming"}),
             ]
 
             SICRephraseClient(data_path=custom_path)
@@ -37,9 +44,9 @@ class TestSICRephraseClient:
         ) as mock_resolve:
             mock_resolve.return_value = "/package/path/example_rephrased_sic_data.csv"
             mock_df = mock_read_csv.return_value
-            mock_df.columns = ["sic_code", "reviewed_description"]
+            mock_df.columns = ["sic_code", "rephrased_description"]
             mock_df.iterrows.return_value = [
-                (0, {"sic_code": "01120", "reviewed_description": "Rice farming"}),
+                (0, {"sic_code": "01120", "rephrased_description": "Rice farming"}),
             ]
 
             SICRephraseClient()
@@ -57,9 +64,9 @@ class TestSICRephraseClient:
         ) as mock_resolve:
             mock_resolve.return_value = "/package/path/example_rephrased_sic_data.csv"
             mock_df = mock_read_csv.return_value
-            mock_df.columns = ["sic_code", "reviewed_description"]
+            mock_df.columns = ["sic_code", "rephrased_description"]
             mock_df.iterrows.return_value = [
-                (0, {"sic_code": "01120", "reviewed_description": "Rice farming"}),
+                (0, {"sic_code": "01120", "rephrased_description": "Rice farming"}),
             ]
 
             SICRephraseClient()
@@ -80,9 +87,9 @@ class TestSICRephraseClient:
         ) as mock_resolve:
             mock_resolve.return_value = "/package/path/example_rephrased_sic_data.csv"
             mock_df = mock_read_csv.return_value
-            mock_df.columns = ["sic_code", "reviewed_description"]
+            mock_df.columns = ["sic_code", "rephrased_description"]
             mock_df.iterrows.return_value = [
-                (0, {"sic_code": "01120", "reviewed_description": "Rice farming"}),
+                (0, {"sic_code": "01120", "rephrased_description": "Rice farming"}),
             ]
 
             SICRephraseClient()
@@ -98,14 +105,14 @@ class TestSICRephraseClient:
     def test_load_rephrase_data_success(self):
         """Test successful loading of rephrase data."""
         test_data = [
-            {"sic_code": "01120", "reviewed_description": "Rice farming"},
-            {"sic_code": "01110", "reviewed_description": "Cereal farming"},
-            {"sic_code": "01130", "reviewed_description": "Vegetable farming"},
+            {"sic_code": "01120", "rephrased_description": "Rice farming"},
+            {"sic_code": "01110", "rephrased_description": "Cereal farming"},
+            {"sic_code": "01130", "rephrased_description": "Vegetable farming"},
         ]
 
         with patch("pandas.read_csv") as mock_read_csv:
             mock_df = mock_read_csv.return_value
-            mock_df.columns = ["sic_code", "reviewed_description"]
+            mock_df.columns = ["sic_code", "rephrased_description"]
             mock_df.iterrows.return_value = list(enumerate(test_data))
 
             client = SICRephraseClient()
@@ -124,7 +131,7 @@ class TestSICRephraseClient:
             mock_df.columns = [
                 "sic_code",
                 "wrong_column",
-            ]  # Missing reviewed_description
+            ]  # Missing rephrased_description
 
             with pytest.raises(HTTPException) as exc_info:
                 SICRephraseClient()
@@ -148,12 +155,12 @@ class TestSICRephraseClient:
     def test_get_rephrased_description(self):
         """Test getting rephrased description for a SIC code."""
         test_data = [
-            {"sic_code": "01120", "reviewed_description": "Rice farming"},
+            {"sic_code": "01120", "rephrased_description": "Rice farming"},
         ]
 
         with patch("pandas.read_csv") as mock_read_csv:
             mock_df = mock_read_csv.return_value
-            mock_df.columns = ["sic_code", "reviewed_description"]
+            mock_df.columns = ["sic_code", "rephrased_description"]
             mock_df.iterrows.return_value = [(0, row) for row in test_data]
 
             client = SICRephraseClient()
@@ -170,12 +177,12 @@ class TestSICRephraseClient:
     def test_has_rephrased_description(self):
         """Test checking if a rephrased description exists."""
         test_data = [
-            {"sic_code": "01120", "reviewed_description": "Rice farming"},
+            {"sic_code": "01120", "rephrased_description": "Rice farming"},
         ]
 
         with patch("pandas.read_csv") as mock_read_csv:
             mock_df = mock_read_csv.return_value
-            mock_df.columns = ["sic_code", "reviewed_description"]
+            mock_df.columns = ["sic_code", "rephrased_description"]
             mock_df.iterrows.return_value = [(0, row) for row in test_data]
 
             client = SICRephraseClient()
@@ -189,14 +196,14 @@ class TestSICRephraseClient:
     def test_get_rephrased_count(self):
         """Test getting the count of rephrased descriptions."""
         test_data = [
-            {"sic_code": "01120", "reviewed_description": "Rice farming"},
-            {"sic_code": "01110", "reviewed_description": "Cereal farming"},
-            {"sic_code": "01130", "reviewed_description": "Vegetable farming"},
+            {"sic_code": "01120", "rephrased_description": "Rice farming"},
+            {"sic_code": "01110", "rephrased_description": "Cereal farming"},
+            {"sic_code": "01130", "rephrased_description": "Vegetable farming"},
         ]
 
         with patch("pandas.read_csv") as mock_read_csv:
             mock_df = mock_read_csv.return_value
-            mock_df.columns = ["sic_code", "reviewed_description"]
+            mock_df.columns = ["sic_code", "rephrased_description"]
             mock_df.iterrows.return_value = list(enumerate(test_data))
 
             client = SICRephraseClient()
@@ -207,13 +214,13 @@ class TestSICRephraseClient:
     def test_process_classification_response(self):
         """Test processing classification response with rephrased descriptions."""
         test_data = [
-            {"sic_code": "01120", "reviewed_description": "Rice farming"},
-            {"sic_code": "01110", "reviewed_description": "Cereal farming"},
+            {"sic_code": "01120", "rephrased_description": "Rice farming"},
+            {"sic_code": "01110", "rephrased_description": "Cereal farming"},
         ]
 
         with patch("pandas.read_csv") as mock_read_csv:
             mock_df = mock_read_csv.return_value
-            mock_df.columns = ["sic_code", "reviewed_description"]
+            mock_df.columns = ["sic_code", "rephrased_description"]
             mock_df.iterrows.return_value = list(enumerate(test_data))
 
             client = SICRephraseClient()
@@ -251,12 +258,12 @@ class TestSICRephraseClient:
     def test_process_classification_response_no_rephrased(self):
         """Test processing response when no rephrased descriptions are available."""
         test_data = [
-            {"sic_code": "01120", "reviewed_description": "Rice farming"},
+            {"sic_code": "01120", "rephrased_description": "Rice farming"},
         ]
 
         with patch("pandas.read_csv") as mock_read_csv:
             mock_df = mock_read_csv.return_value
-            mock_df.columns = ["sic_code", "reviewed_description"]
+            mock_df.columns = ["sic_code", "rephrased_description"]
             mock_df.iterrows.return_value = [(0, row) for row in test_data]
 
             client = SICRephraseClient()
@@ -276,12 +283,12 @@ class TestSICRephraseClient:
     def test_process_classification_response_empty_data(self):
         """Test processing response with empty or missing data."""
         test_data = [
-            {"sic_code": "01120", "reviewed_description": "Rice farming"},
+            {"sic_code": "01120", "rephrased_description": "Rice farming"},
         ]
 
         with patch("pandas.read_csv") as mock_read_csv:
             mock_df = mock_read_csv.return_value
-            mock_df.columns = ["sic_code", "reviewed_description"]
+            mock_df.columns = ["sic_code", "rephrased_description"]
             mock_df.iterrows.return_value = [(0, row) for row in test_data]
 
             client = SICRephraseClient()

--- a/tests/test_sic_rephrase_client.py
+++ b/tests/test_sic_rephrase_client.py
@@ -32,9 +32,10 @@ class TestSICRephraseClient:
 
     def test_init_with_config_path(self):
         """Test initialisation using package data path (environment variables ignored)."""
-        with patch("pandas.read_csv") as mock_read_csv, patch(
-            "api.services.sic_rephrase_client.resolve_package_data_path"
-        ) as mock_resolve:
+        with (
+            patch("pandas.read_csv") as mock_read_csv,
+            patch("api.services.sic_rephrase_client.resolve_package_data_path") as mock_resolve,
+        ):
             mock_resolve.return_value = "/package/path/example_rephrased_sic_data.csv"
             mock_df = mock_read_csv.return_value
             mock_df.columns = ["sic_code", "reviewed_description"]
@@ -52,9 +53,10 @@ class TestSICRephraseClient:
 
     def test_init_with_package_fallback(self):
         """Test initialisation using package data (environment variables ignored)."""
-        with patch("pandas.read_csv") as mock_read_csv, patch(
-            "api.services.sic_rephrase_client.resolve_package_data_path"
-        ) as mock_resolve:
+        with (
+            patch("pandas.read_csv") as mock_read_csv,
+            patch("api.services.sic_rephrase_client.resolve_package_data_path") as mock_resolve,
+        ):
             mock_resolve.return_value = "/package/path/example_rephrased_sic_data.csv"
             mock_df = mock_read_csv.return_value
             mock_df.columns = ["sic_code", "reviewed_description"]
@@ -69,15 +71,14 @@ class TestSICRephraseClient:
             call_args = mock_read_csv.call_args[0][0]
             # Check for package data path
             assert "/package/path/example_rephrased_sic_data.csv" in call_args
-            mock_resolve.assert_called_once_with(
-                "industrial_classification.data", "example_rephrased_sic_data.csv"
-            )
+            mock_resolve.assert_called_once_with("industrial_classification.data", "example_rephrased_sic_data.csv")
 
     def test_init_with_sic_library_path(self):
         """Test initialisation using package data path (environment variables ignored)."""
-        with patch("pandas.read_csv") as mock_read_csv, patch(
-            "api.services.sic_rephrase_client.resolve_package_data_path"
-        ) as mock_resolve:
+        with (
+            patch("pandas.read_csv") as mock_read_csv,
+            patch("api.services.sic_rephrase_client.resolve_package_data_path") as mock_resolve,
+        ):
             mock_resolve.return_value = "/package/path/example_rephrased_sic_data.csv"
             mock_df = mock_read_csv.return_value
             mock_df.columns = ["sic_code", "reviewed_description"]
@@ -117,6 +118,25 @@ class TestSICRephraseClient:
             expected_count = 3
             assert client.get_rephrased_count() == expected_count
 
+    def test_load_rephrase_data_success_with_rephrased_column(self):
+        """Test successful loading when using the current description column name."""
+        test_data = [
+            {"sic_code": "01120", "rephrased_description": "Rice farming"},
+            {"sic_code": "01110", "rephrased_description": "Cereal farming"},
+        ]
+
+        with patch("pandas.read_csv") as mock_read_csv:
+            mock_df = mock_read_csv.return_value
+            mock_df.columns = ["sic_code", "rephrased_description"]
+            mock_df.iterrows.return_value = list(enumerate(test_data))
+
+            client = SICRephraseClient()
+
+            assert client.get_rephrased_description("01120") == "Rice farming"
+            assert client.get_rephrased_description("01110") == "Cereal farming"
+            expected_count = 2
+            assert client.get_rephrased_count() == expected_count
+
     def test_load_rephrase_data_missing_columns(self):
         """Test loading data with missing required columns."""
         with patch("pandas.read_csv") as mock_read_csv:
@@ -124,14 +144,14 @@ class TestSICRephraseClient:
             mock_df.columns = [
                 "sic_code",
                 "wrong_column",
-            ]  # Missing reviewed_description
+            ]  # Missing rephrased_description and reviewed_description
 
             with pytest.raises(HTTPException) as exc_info:
                 SICRephraseClient()
 
             expected_status_code = 500
             assert exc_info.value.status_code == expected_status_code
-            assert "CSV file must contain columns" in str(exc_info.value.detail)
+            assert "rephrased_description or reviewed_description" in str(exc_info.value.detail)
 
     def test_load_rephrase_data_file_not_found(self):
         """Test handling of missing data file."""
@@ -244,9 +264,7 @@ class TestSICRephraseClient:
             # Check that candidate descriptions were rephrased where available
             candidates = processed_response["sic_candidates"]
             assert candidates[0]["sic_descriptive"] == "Cereal farming"
-            assert (
-                candidates[1]["sic_descriptive"] == "Some other activity"
-            )  # Unchanged
+            assert candidates[1]["sic_descriptive"] == "Some other activity"  # Unchanged
 
     def test_process_classification_response_no_rephrased(self):
         """Test processing response when no rephrased descriptions are available."""

--- a/tests/test_sic_rephrase_client.py
+++ b/tests/test_sic_rephrase_client.py
@@ -14,6 +14,13 @@ logger = get_logger(__name__)
 class TestSICRephraseClient:
     """Test cases for the SIC rephrase client."""
 
+    def test_init_with_non_string_path(self):
+        """Test initialisation rejects non-string data paths."""
+        with pytest.raises(ValueError) as exc_info:
+            SICRephraseClient(data_path=123)
+
+        assert str(exc_info.value) == "Data path must be a string"
+
     def test_init_with_custom_path(self):
         """Test initialisation with a custom data path."""
         custom_path = "/custom/path/rephrased.csv"
@@ -152,6 +159,19 @@ class TestSICRephraseClient:
             expected_status_code = 500
             assert exc_info.value.status_code == expected_status_code
             assert "rephrased_description or reviewed_description" in str(exc_info.value.detail)
+
+    def test_load_rephrase_data_missing_sic_code_column(self):
+        """Test loading data with no sic_code column."""
+        with patch("pandas.read_csv") as mock_read_csv:
+            mock_df = mock_read_csv.return_value
+            mock_df.columns = ["rephrased_description"]
+
+            with pytest.raises(HTTPException) as exc_info:
+                SICRephraseClient()
+
+            expected_status_code = 500
+            assert exc_info.value.status_code == expected_status_code
+            assert "CSV file must contain column: sic_code" in str(exc_info.value.detail)
 
     def test_load_rephrase_data_file_not_found(self):
         """Test handling of missing data file."""

--- a/tests/test_sic_rephrase_client.py
+++ b/tests/test_sic_rephrase_client.py
@@ -41,7 +41,9 @@ class TestSICRephraseClient:
         """Test initialisation using package data path (environment variables ignored)."""
         with (
             patch("pandas.read_csv") as mock_read_csv,
-            patch("api.services.sic_rephrase_client.resolve_package_data_path") as mock_resolve,
+            patch(
+                "api.services.sic_rephrase_client.resolve_package_data_path"
+            ) as mock_resolve,
         ):
             mock_resolve.return_value = "/package/path/example_rephrased_sic_data.csv"
             mock_df = mock_read_csv.return_value
@@ -62,7 +64,9 @@ class TestSICRephraseClient:
         """Test initialisation using package data (environment variables ignored)."""
         with (
             patch("pandas.read_csv") as mock_read_csv,
-            patch("api.services.sic_rephrase_client.resolve_package_data_path") as mock_resolve,
+            patch(
+                "api.services.sic_rephrase_client.resolve_package_data_path"
+            ) as mock_resolve,
         ):
             mock_resolve.return_value = "/package/path/example_rephrased_sic_data.csv"
             mock_df = mock_read_csv.return_value
@@ -78,13 +82,17 @@ class TestSICRephraseClient:
             call_args = mock_read_csv.call_args[0][0]
             # Check for package data path
             assert "/package/path/example_rephrased_sic_data.csv" in call_args
-            mock_resolve.assert_called_once_with("industrial_classification.data", "example_rephrased_sic_data.csv")
+            mock_resolve.assert_called_once_with(
+                "industrial_classification.data", "example_rephrased_sic_data.csv"
+            )
 
     def test_init_with_sic_library_path(self):
         """Test initialisation using package data path (environment variables ignored)."""
         with (
             patch("pandas.read_csv") as mock_read_csv,
-            patch("api.services.sic_rephrase_client.resolve_package_data_path") as mock_resolve,
+            patch(
+                "api.services.sic_rephrase_client.resolve_package_data_path"
+            ) as mock_resolve,
         ):
             mock_resolve.return_value = "/package/path/example_rephrased_sic_data.csv"
             mock_df = mock_read_csv.return_value
@@ -158,7 +166,9 @@ class TestSICRephraseClient:
 
             expected_status_code = 500
             assert exc_info.value.status_code == expected_status_code
-            assert "rephrased_description or reviewed_description" in str(exc_info.value.detail)
+            assert "rephrased_description or reviewed_description" in str(
+                exc_info.value.detail
+            )
 
     def test_load_rephrase_data_missing_sic_code_column(self):
         """Test loading data with no sic_code column."""
@@ -171,7 +181,9 @@ class TestSICRephraseClient:
 
             expected_status_code = 500
             assert exc_info.value.status_code == expected_status_code
-            assert "CSV file must contain column: sic_code" in str(exc_info.value.detail)
+            assert "CSV file must contain column: sic_code" in str(
+                exc_info.value.detail
+            )
 
     def test_load_rephrase_data_file_not_found(self):
         """Test handling of missing data file."""
@@ -284,7 +296,9 @@ class TestSICRephraseClient:
             # Check that candidate descriptions were rephrased where available
             candidates = processed_response["sic_candidates"]
             assert candidates[0]["sic_descriptive"] == "Cereal farming"
-            assert candidates[1]["sic_descriptive"] == "Some other activity"  # Unchanged
+            assert (
+                candidates[1]["sic_descriptive"] == "Some other activity"
+            )  # Unchanged
 
     def test_process_classification_response_no_rephrased(self):
         """Test processing response when no rephrased descriptions are available."""


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

This PR provides compatibility with the new `sic_rephrased_2025_02_03_v2.csv` file, which contains a `"rephrased_description"` column instead of a `"reviewed_description"` column. It maintains backward-compatibility with both column names currently, but this could be changed if we want to lock down the new column name.

## 📜 Changes Introduced

- Rename `"reviewed_description"` to `"rephrased_description"` ~~but maintain compatibility with the legacy column name~~
- Use the new structured logging approach with the `survey_assist_utils.logging.get_logger()` function.

- [x] Feature implementation (feat:) / bug fix (fix:) / refactoring (chore:) / documentation (docs:) / testing (test:)
- [ ] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [x] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

Download the new files from the GCS bucket into the `data/` directory:

```bash
gsutil cp "gs://ons-survey-assist-dev-cloud-run-services/api_config/data/*" "data/"
```

Set environment variables that point to the new files:

```
SIC_LOOKUP_DATA_PATH="data/sic_knowledge_base_utf8.csv"
SIC_REPHRASE_DATA_PATH="data/sic_rephrased_2025_02_03_v2.csv"
SOC_LOOKUP_DATA_PATH="data/soc_knowledge_base_utf8_SA-649.csv"
SOC_REPHRASE_DATA_PATH="data/soc_rephrased_2026_04_17_nec_only.csv"
```

Run the main API

```bash
make run-api
```

Run the `sic-classification-vector-store` API.

Go to `http://0.0.0.0:8080/docs` and test out the `/v1/survey-assist/classify` endpoint.