### PR TITLE
refactor(api): Use the StatusResponse model in the response schema

### DIFF
--- a/api/models/embeddings.py
+++ b/api/models/embeddings.py
@@ -45,20 +45,20 @@ class StatusResponse(BaseModel):
 
 EMBEDDINGS_STATUS_EXAMPLE = StatusResponse(
     status="ready",
-    embedding_model_name="text-embedding-004",
-    db_dir="/app/data/vector_store",
+    embedding_model_name="all-MiniLM-L6-v2",
+    db_dir="src/sic_classification_vector_store/data/vector_store",
     sic_index_source=FileSource(
-        package="industrial_classification_utils",
-        file="data/sic_2007_index.csv",
+        package="sic_classification_vector_store.data.sic_index",
+        file="uksic2007indexeswithaddendumdecember2022.xlsx",
     ),
     sic_structure_source=FileSource(
-        package="industrial_classification_utils",
-        file="data/sic_2007_structure.xlsx",
+        package="sic_classification_vector_store.data.sic_index",
+        file="publisheduksicsummaryofstructureworksheet.xlsx",
     ),
     sic_condensed_source=FileSource(
-        package="industrial_classification_utils",
-        file="data/sic_2007_condensed.csv",
+        package="industrial_classification_utils.data.example",
+        file="sic_2d_condensed.txt",
     ),
     matches=20,
-    index_size=1234,
+    index_size=16618,
 ).model_dump()

--- a/api/models/embeddings.py
+++ b/api/models/embeddings.py
@@ -1,0 +1,64 @@
+"""This module contains the models for the status response.
+
+The models in this module are used to represent the response
+returned by the embeddings endpoint in the API.
+"""
+
+from pydantic import BaseModel
+
+
+class FileSource(BaseModel):
+    """Model representing a file source for the vector store.
+
+    Attributes:
+        package (str): The name of the package containing the file.
+        file (str): The name of the file.
+    """
+
+    package: str
+    file: str
+
+
+class StatusResponse(BaseModel):
+    """Model representing the vector store status response.
+
+    Attributes:
+        embedding_model_name (str): The name of the embeddings model.
+        db_dir (str): The vector store directory.
+        sic_index_source (FileSource): The SIC index source file.
+        sic_structure_source (FileSource): The SIC structure source file.
+        sic_condensed_source (FileSource): The condensed SIC reference file.
+        matches (int): The number of nearest matches initialised in the vector store.
+        index_size (int): The number of embedded entries in the vector store.
+        status (str): The status of the vector store.
+    """
+
+    status: str
+    embedding_model_name: str
+    db_dir: str
+    sic_index_source: FileSource
+    sic_structure_source: FileSource
+    sic_condensed_source: FileSource
+    matches: int
+    index_size: int
+
+
+EMBEDDINGS_STATUS_EXAMPLE = StatusResponse(
+    status="ready",
+    embedding_model_name="text-embedding-004",
+    db_dir="/app/data/vector_store",
+    sic_index_source=FileSource(
+        package="industrial_classification_utils",
+        file="data/sic_2007_index.csv",
+    ),
+    sic_structure_source=FileSource(
+        package="industrial_classification_utils",
+        file="data/sic_2007_structure.xlsx",
+    ),
+    sic_condensed_source=FileSource(
+        package="industrial_classification_utils",
+        file="data/sic_2007_condensed.csv",
+    ),
+    matches=20,
+    index_size=1234,
+).model_dump()

--- a/api/routes/v1/embeddings.py
+++ b/api/routes/v1/embeddings.py
@@ -17,6 +17,10 @@ from api.services.sic_vector_store_client import SICVectorStoreClient
 router = APIRouter(tags=["Embeddings"])
 logger = get_logger(__name__)
 
+EMBEDDINGS_STATUS_UNAVAILABLE_EXAMPLE = {
+    "detail": "Failed to check SIC vector store status: All connection attempts failed"
+}
+
 
 def get_vector_store_client() -> SICVectorStoreClient:
     """Get a vector store client instance.
@@ -45,7 +49,13 @@ def get_vector_store_client() -> SICVectorStoreClient:
         200: {
             "description": "Current SIC vector store status",
             "content": {"application/json": {"example": EMBEDDINGS_STATUS_EXAMPLE}},
-        }
+        },
+        503: {
+            "description": "The SIC vector store service is unavailable",
+            "content": {
+                "application/json": {"example": EMBEDDINGS_STATUS_UNAVAILABLE_EXAMPLE}
+            },
+        },
     },
 )
 async def get_embeddings_status(

--- a/api/routes/v1/embeddings.py
+++ b/api/routes/v1/embeddings.py
@@ -6,10 +6,12 @@ It defines the endpoint for checking the status of the embeddings in the vector 
 
 import os
 import time
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from survey_assist_utils.logging import get_logger
 
+from api.models.embeddings import EMBEDDINGS_STATUS_EXAMPLE, StatusResponse
 from api.services.sic_vector_store_client import SICVectorStoreClient
 
 router = APIRouter(tags=["Embeddings"])
@@ -36,29 +38,28 @@ def get_vector_store_client() -> SICVectorStoreClient:
     return SICVectorStoreClient(base_url=base_url)
 
 
-# Define the dependency at module level
-vector_store_client_dependency = Depends(get_vector_store_client)
-
-
-@router.get("/embeddings")
+@router.get(
+    "/embeddings",
+    response_model=StatusResponse,
+    responses={
+        200: {
+            "description": "Current SIC vector store status",
+            "content": {"application/json": {"example": EMBEDDINGS_STATUS_EXAMPLE}},
+        }
+    },
+)
 async def get_embeddings_status(
-    vector_store_client: SICVectorStoreClient = vector_store_client_dependency,
-) -> dict:
+    vector_store_client: Annotated[
+        SICVectorStoreClient, Depends(get_vector_store_client)
+    ],
+) -> StatusResponse:
     """Get the status of the embeddings in the vector store.
 
     Args:
         vector_store_client: The vector store client instance.
 
     Returns:
-        dict: A dictionary containing the status of the embeddings.
-
-    Example:
-        ```json
-        {
-            "status": "ready",
-            "message": "Embeddings are loaded and ready to query"
-        }
-        ```
+        StatusResponse: The status of the embeddings.
     """
     start_time = time.perf_counter()
     logger.info("Request received for embeddings status")
@@ -71,4 +72,4 @@ async def get_embeddings_status(
         ),
         duration_ms=str(duration_ms),
     )
-    return status
+    return StatusResponse.model_validate(status)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,6 +23,7 @@ import pytest
 from fastapi import HTTPException
 from survey_assist_utils.logging import get_logger
 
+from api.models.embeddings import EMBEDDINGS_STATUS_EXAMPLE
 from api.services.sic_vector_store_client import SICVectorStoreClient
 
 logger = get_logger(__name__)
@@ -84,7 +85,7 @@ async def test_get_status_success():
     - The response matches the expected status dictionary.
     """
     mock_response = AsyncMock()
-    mock_response.json = Mock(return_value={"status": "ready"})
+    mock_response.json = Mock(return_value=EMBEDDINGS_STATUS_EXAMPLE)
     mock_response.raise_for_status = AsyncMock()
 
     mock_client = AsyncMock()
@@ -92,13 +93,16 @@ async def test_get_status_success():
     mock_client.__aexit__.return_value = None
     mock_client.get.return_value = mock_response
 
-    with patch("httpx.AsyncClient", return_value=mock_client), patch(
-        "api.services.base_vector_store_client.BaseVectorStoreClient._get_auth_headers",
-        return_value={},
+    with (
+        patch("httpx.AsyncClient", return_value=mock_client),
+        patch(
+            "api.services.base_vector_store_client.BaseVectorStoreClient._get_auth_headers",
+            return_value={},
+        ),
     ):
         client = SICVectorStoreClient(base_url="http://localhost:8088")
         response = await client.get_status()
-        assert response == {"status": "ready"}
+        assert response == EMBEDDINGS_STATUS_EXAMPLE
 
 
 @pytest.mark.api
@@ -116,11 +120,12 @@ async def test_get_status_connection_error():
     - The raised exception has the correct status code.
     - The error message contains the expected connection failure text.
     """
-    with patch(
-        "httpx.AsyncClient.get", side_effect=httpx.HTTPError("Connection error")
-    ), patch(
-        "api.services.base_vector_store_client.BaseVectorStoreClient._get_auth_headers",
-        return_value={},
+    with (
+        patch("httpx.AsyncClient.get", side_effect=httpx.HTTPError("Connection error")),
+        patch(
+            "api.services.base_vector_store_client.BaseVectorStoreClient._get_auth_headers",
+            return_value={},
+        ),
     ):
         client = SICVectorStoreClient(base_url="http://nonexistent:8088")
         with pytest.raises(HTTPException) as exc_info:
@@ -145,7 +150,7 @@ def test_embeddings_endpoint(test_client):
     with patch(
         "api.services.sic_vector_store_client.SICVectorStoreClient.get_status"
     ) as mock_get_status:
-        mock_get_status.return_value = {"status": "ready"}
+        mock_get_status.return_value = EMBEDDINGS_STATUS_EXAMPLE
         response = test_client.get("/v1/survey-assist/embeddings")
         assert response.status_code == HTTPStatus.OK
-        assert response.json() == {"status": "ready"}
+        assert response.json() == EMBEDDINGS_STATUS_EXAMPLE

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,9 +24,32 @@ from fastapi import HTTPException
 from survey_assist_utils.logging import get_logger
 
 from api.models.embeddings import EMBEDDINGS_STATUS_EXAMPLE
+from api.routes.v1.embeddings import get_vector_store_client
 from api.services.sic_vector_store_client import SICVectorStoreClient
 
 logger = get_logger(__name__)
+
+
+@pytest.mark.api
+@pytest.mark.parametrize(
+    ("env_value", "expected_base_url"),
+    [
+        ("  http://vector-store.internal:8088  ", "http://vector-store.internal:8088"),
+        (None, "http://localhost:8088"),
+    ],
+)
+def test_get_vector_store_client_uses_expected_base_url(
+    monkeypatch, env_value, expected_base_url
+):
+    """Test vector store client URL resolution from environment and fallback."""
+    if env_value is None:
+        monkeypatch.delenv("SIC_VECTOR_STORE", raising=False)
+    else:
+        monkeypatch.setenv("SIC_VECTOR_STORE", env_value)
+
+    client = get_vector_store_client()
+
+    assert client.base_url == expected_base_url
 
 
 @pytest.mark.api


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

This PR updates the `/v1/embeddings/` endpoint to have a properly typed `StatusResponse` model defined using Pydantic, with an example used in a way conformant with FastAPI and OpenAPI/Swagger docs integration.

## 📜 Changes Introduced

<!-- List key changes made in this PR. Consider bullet points for readability. -->

- [x] Feature implementation (feat:) / bug fix (fix:) / refactoring (chore:) / documentation (docs:) / testing (test:)
- [ ] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

Run the api in this repo:

```bash
make run-api
```
and `sic-classification-vector-store`

```bash
cd ../sic-classification-vector-store
make run-vector-store
```

Got to the `/docs` endpoint at http://0.0.0.0:8080/docs and confirm that the response model for `/v1/survey-assist/embeddings` is accurate in the OpenAPI docs example responses.

Try out the endpoint and confirm that it returns a response similar to the example.

Close down the `sic-classification-vector-store` API. Try the `/v1/survey-assist/embeddings` endpoint again, and confirm that the 503 response is the same as the example in the docs.