### PR TITLE
SA-693/two step classify

### DIFF
--- a/SIC_SOC_ENDPOINT_CALLS_MASTER.md
+++ b/SIC_SOC_ENDPOINT_CALLS_MASTER.md
@@ -1,0 +1,1021 @@
+# SIC + SOC Comprehensive Local Call Test Runbook
+
+**Last full SIC run:** 2026-04-28 14:33:37  
+**Last SOC / SA-693 run:** 2026-05-19 (two-step classify verified live; farm hand + vague Worker case; see caveat below)
+
+This runbook consolidates and extends coverage from:
+- `SA-693-task.md` (two-step SOC classify)
+- `SOC_REPHRASE_MANUAL_TEST.md`
+- `SA-649-live-curl-results.md`
+- `SA-673-local-api-test-results.md`
+- `SA-559-soc-lookup-testing.md`
+- `README.md`, `docs/index.md`, and `docs/guide.md`
+
+## SA-693 — SOC classify (two-step)
+
+SOC classify on `POST /v1/survey-assist/classify` (`type`: `soc` or `sic_soc`) now mirrors SIC:
+
+1. SOC vector store search → short list (`code`, `title`, `distance`).
+2. **`unambiguous_soc_code`** — if `codable` and `class_code` set → `classified: true`, `followup: null`, final `code` / `description`.
+3. Else **`formulate_open_question`** — `classified: false`, non-null `followup`, `code` / `description` null; candidates from step 2.
+
+Removed from the API: SA-673 clear-winner promotion (`_select_soc_clear_winner`). Classify does **not** call `sa_rag_soc_code`.
+
+### Prerequisites (local)
+
+```bash
+# survey-assist-api — path dep to SA-693 utils on branch SA-693/two-step-classify
+cd survey-assist-api && poetry install
+
+export SOC_VECTOR_STORE="http://localhost:8089"
+export SOC_LOOKUP_DATA_PATH="data/soc_knowledge_base_utf8_SA-649.csv"
+export SOC_REPHRASE_DATA_PATH="data/soc_rephrased_2026_04_17_nec_only.csv"
+
+# Gemini / Vertex (required for classify)
+gcloud auth application-default login
+
+# Terminal 1: soc-classification-vector-store
+make run-vector-store   # port 8089
+
+# Terminal 2: survey-assist-api (restart after poetry install)
+make run-api            # port 8080
+```
+
+Run the curl commands in the sections below (for example `CLASSIFY_SOC_UNAMBIGUOUS`, `SOC_VS_STATUS`). For SOC-only testing, skip `CLASSIFY_SIC_SOC` unless the SIC vector store is running on port **8088**.
+
+**Gemini auth:** run `gcloud auth application-default login` in your terminal, then **restart** `make run-api` in the same session (or export ADC in the shell that starts uvicorn). Without valid ADC, startup logs show `RefreshError` and `soc_llm` stays unset.
+
+### SA-693 acceptance checks (classify)
+
+| Case | Expected |
+|---|---|
+| `CLASSIFY_SOC_UNAMBIGUOUS` (farm hand) | HTTP `200`, `classified: true`, `code: "9111"`, `followup: null` |
+| `CLASSIFY_SOC_AMBIGUOUS` / finance manager | HTTP `200`, `classified: false`, non-empty `followup`, `code: null` (see caveat) |
+| `CLASSIFY_SOC_REPHRASE_*` | Same branching; rephrase only affects text passed to vector search / LLM |
+| `CLASSIFY_SIC_SOC` | SIC result unchanged; SOC leg uses two-step flow |
+
+**Caveat — finance manager is not a reliable live test for step 2:** On 2026-05-19, live Gemini often returned `codable: true` from `unambiguous_soc_code` for the finance-manager payload (`classified: true`, `code: "1131"`, only one LLM call in API logs). That matches SIC: step 2 runs when the first LLM sets `codable: false`, not when candidate likelihoods are close. To verify `formulate_open_question` live, use a genuinely vague job (for example `job_title: "Worker"`, `job_description: "I do various tasks depending on what is needed each day"`) or rely on `test_soc_not_codable_returns_followup` in `tests/test_classify.py` (mocked `codable: false`).
+
+## Scope
+
+Covers local call behaviour for:
+- SIC lookup endpoint (`/v1/survey-assist/sic-lookup`) – exact, similarity, validation, unknown
+- SOC lookup endpoint (`/v1/survey-assist/soc-lookup`) – exact, similarity, validation, unknown
+- SOC vector store (`/v1/soc-vector-store/status`, search used by classify)
+- Classification endpoint (`/v1/survey-assist/classify`) – `sic`, `soc`, `sic_soc`, options on/off, validation
+- Supporting service checks (`/`, `/config`, `/embeddings`)
+
+## Expected Non-200 Cases
+
+These are intentional validation checks in this suite and should not be treated as platform failures:
+- `SIC_LOOKUP_EMPTY` returns `400 Bad Request` (empty `description`)
+- `SOC_LOOKUP_EMPTY` returns `400 Bad Request` (empty `description`)
+- `SOC_LOOKUP_UNKNOWN` returns `404 Not Found` (no matching SOC code)
+- `CLASSIFY_INVALID_TYPE` returns `422 Unprocessable Entity` (`type` must be `sic`, `soc`, or `sic_soc`)
+
+## Summary
+
+| Case | Method | HTTP (expected) | Notes |
+|---|---|---:|---|
+| `ROOT_HEALTH` | `GET` | `200` | |
+| `CONFIG` | `GET` | `200` | |
+| `EMBEDDINGS` | `GET` | `200` | SIC vector store |
+| `SIC_LOOKUP_*` | `GET` | see SIC sections | unchanged |
+| `SOC_VS_STATUS` | `GET` | `200` | `http://localhost:8089` |
+| `SOC_LOOKUP_EXACT` | `GET` | `200` | 2026-05-19 verified |
+| `SOC_LOOKUP_SIMILARITY` | `GET` | `200` | 2026-05-19 verified |
+| `SOC_LOOKUP_EMPTY` | `GET` | `400` | 2026-05-19 verified |
+| `SOC_LOOKUP_UNKNOWN` | `GET` | `404` | was `200` in 2026-04 run |
+| `CLASSIFY_SIC_*` | `POST` | `200` | SIC sections below (2026-04) |
+| `CLASSIFY_SOC_UNAMBIGUOUS` | `POST` | `200` | SA-693 farm hand → `9111` |
+| `CLASSIFY_SOC_AMBIGUOUS` | `POST` | `200` | SA-693 step 2 — finance manager often codable; see caveat |
+| `CLASSIFY_SOC_REPHRASE_FALSE` | `POST` | `200` | re-run after SA-693 |
+| `CLASSIFY_SOC_REPHRASE_TRUE` | `POST` | `200` | re-run after SA-693 |
+| `CLASSIFY_SOC_DEFAULT` | `POST` | `200` | default rephrase on |
+| `CLASSIFY_SIC_SOC` | `POST` | `200` | **skip** unless SIC vector store on `:8088` is running |
+| `CLASSIFY_INVALID_TYPE` | `POST` | `422` | |
+
+## ROOT_HEALTH
+
+API root availability
+
+Command run:
+
+```bash
+curl -sS -m 120 -X GET "http://localhost:8080/"
+```
+
+Result: HTTP `200` in `0.001280` seconds
+
+Response body:
+
+```json
+{
+  "message": "Survey Assist API is running"
+}
+```
+
+## CONFIG
+
+Config endpoint returns runtime settings
+
+Command run:
+
+```bash
+curl -sS -m 120 -X GET "http://localhost:8080/v1/survey-assist/config"
+```
+
+Result: HTTP `200` in `8.839051` seconds
+
+Response body:
+
+```json
+{
+  "llm_model": "gemini-2.5-flash",
+  "data_store": "Firestore",
+  "firestore_database_id": "survey-assist-db",
+  "v1v2": {
+    "classification": [
+      {
+        "type": "sic",
+        "prompts": [
+          {
+            "name": "SA_SIC_PROMPT_RAG",
+            "text": "You are a conscientious classification assistant of respondent data\nfor the use in the UK official statistics. Respondent data may be in English or Welsh,\nbut you always respond in British English.\"Given the respondent's description of the main activity their\ncompany does, their job title and job description (which may be different to the\nmain company activity), your task is to determine a list of the most likely UK SIC\n(Standard Industry Classification) codes for this company and the final code\nthat is most likely to match the description.\n\nThe following will be provided to make your decision and send appropriate output:\nRespondent Data\nRelevant subset of UK SIC 2007 (you must only use this list to classify)\nOutput Format (the output format MUST be valid JSON)\n\nOnly use the subset of UK SIC 2007 provided to determine if you can match the most\nlikely sic codes, provide a confidence score between 0 and 1 where 0.1 is least\nlikely and 0.9 is most likely.\n\nYou must return a subset list of possible sic codes (UK SIC 2007 codes provided)\nthat might match with a confidence score for each.\n\nYou must provide a follow up question that would help identify the exact coding based\non the list you respond with.\n\nAlways provide reasoning for your decision.\n\n\n===Respondent Data===\n- Company's main activity: {industry_descr}\n- Job Title: {job_title}\n- Job Description: {job_description}\n\n===Relevant subset of UK SIC 2007===\n{sic_index}\n\n===Output Format===\n{format_instructions}\n\n===Output===\n"
+          }
+        ]
+      }
+    ]
+  },
+  "v3": {
+    "classification": [
+      {
+        "type": "sic",
+        "prompts": [
+          {
+            "name": "SIC_PROMPT_RERANKER",
+            "text": "You are a conscientious classification assistant of respondent data\nfor the use in the UK official statistics. Respondent data may be in English or Welsh,\nbut you always respond in British English.\"You are a precise semantic matching system.\nYour task is to re-rank and select the N most relevant UK SIC (Standard Industry\nClassification) codes from a provided list of candidates based on their relevance\nto the respondent's description.\n\n===Task Description===\n\nAnalyze each candidate SIC code's relevance to the query.\nScore each candidate on a scale of 0.0 to 1.0 based on semantic similarity and\nbusiness context alignment.\nSelect the top N most relevant codes.\nProvide clear reasoning for your scoring decisions.\nYour response must be a single JSON object with NO additional text or formatting.\n\n===Scoring Criteria===\n\nPrimary Activity Match (0.0-0.4):\n\nEvaluates the fundamental alignment between the query and the code's main\nbusiness activity\n\nScoring guidelines:\n\n0.35-0.4: Perfect match (e.g., \"Beer brewery\" → \"Manufacture of beer\")\n0.25-0.34: Strong match with minor differences (e.g., \"Craft brewery\" →\n\"Manufacture of beer\")\n0.15-0.24: Related activity in same sector (e.g., \"Beer distribution\" →\n\"Manufacture of beer\")\n0.05-0.14: Tangentially related activity (e.g., \"Beer tasting\" →\n\"Manufacture of beer\")\n0.0-0.04: Minimal or no relation to primary activity\n\n\nContext Precision (0.0-0.3):\n\nMeasures how specifically the code captures the business context of the query\nConsiders industry position (manufacturing, wholesale, retail, service)\nScoring guidelines:\n\n0.25-0.3: Exact business context match (e.g., manufacturing vs. retail context)\n0.15-0.24: Related context with same business model\n0.05-0.14: Similar industry but different business model\n0.0-0.04: Different business context entirely\n\n\nExamples:\n\nQuery \"Beer shop\" matching \"Retail sale of beverages\" (high precision)\nQuery \"Beer shop\" matching \"Wholesale of beverages\" (medium precision)\nQuery \"Beer shop\" matching \"Manufacture of beer\" (low precision)\n\n\nExample Activity Alignment (0.0-0.3):\n\nEvaluates matches between query and specific example activities listed under the code\nConsiders both exact matches and semantic similarity\n\nScoring guidelines:\n\n0.25-0.3: Direct match with example activities\n0.15-0.24: Semantic equivalence to example activities\n0.05-0.14: Partial overlap with example activities\n0.0-0.04: No matching example activities\n\n\nSpecial considerations:\n\nMultiple matching examples increase score within range\nIndustry-specific terminology matches are weighted heavily\nGeneric matches receive lower scores\n\n===Input Data===\n- Company's main activity: {industry_descr}\n- Job Title: {job_title}\n- Job Description: {job_description}\n- Number of codes to select (N): {n}\n\n===UK SIC 2007 candidates===\n{sic_index}\n\n===Requirements===\n\nScores must be between 0.0 and 1.0\nSe
+... (truncated)
+```
+
+## EMBEDDINGS
+
+Vector-store connectivity/status check
+
+Command run:
+
+```bash
+curl -sS -m 120 -X GET "http://localhost:8080/v1/survey-assist/embeddings"
+```
+
+Result: HTTP `200` in `2.771733` seconds
+
+Response body:
+
+```json
+{
+  "status": "ready",
+  "embedding_model_name": "all-MiniLM-L6-v2",
+  "llm_model_name": "",
+  "db_dir": "src/sic_classification_vector_store/data/vector_store",
+  "sic_index_file": "('sic_classification_vector_store.data.sic_index', 'uksic2007indexeswithaddendumdecember2022.xlsx')",
+  "sic_structure_file": "('sic_classification_vector_store.data.sic_index', 'publisheduksicsummaryofstructureworksheet.xlsx')",
+  "sic_condensed_file": "('industrial_classification_utils.data.example', 'sic_2d_condensed.txt')",
+  "matches": 20,
+  "index_size": 16618
+}
+```
+
+## SIC_LOOKUP_EXACT
+
+SIC exact lookup
+
+Command run:
+
+```bash
+curl -sS -m 120 -X GET "http://localhost:8080/v1/survey-assist/sic-lookup?description=electrical%20installation&similarity=false"
+```
+
+Result: HTTP `200` in `0.001138` seconds
+
+Response body:
+
+```json
+{
+  "description": "electrical installation",
+  "code": "43210",
+  "code_meta": {
+    "code": "4321x",
+    "title": "Electrical installation",
+    "detail": "This class includes the installation of electrical systems in all kinds of buildings and civil engineering structures of electrical systems.",
+    "includes": [
+      "installation of: electrical wiring and fittings telecommunications wiring computer network and cable television wiring, including fibre optic satellite dishes lighting systems fire alarms burglar alarm systems street lighting and electrical signals airport runway lighting electric solar energy collectors",
+      "connecting of electric appliances and household equipment, including baseboard heating"
+    ],
+    "excludes": [
+      "construction of communications and power transmission lines, see ##42.22",
+      "monitoring and remote monitoring of electronic security systems, such as burglar alarms and fire alarms, including their installation and maintenance, see ##80.20"
+    ]
+  },
+  "code_division": "43",
+  "code_division_meta": {
+    "code": "43xxx",
+    "title": "Specialised construction activities",
+    "detail": "This division includes specialised construction activities (special trades), i.e. the construction, or preparation for construction, of parts of buildings and civil engineering works. These activities are usually specialised in one aspect common to different structures, requiring specialised skills or equipment, such as pile-driving, foundation work, carcass work, concrete work, brick laying, stone setting, scaffolding, roof covering, etc. The erection of steel structures is included provided that the parts are not produced by the same unit. Specialised construction activities are mostly carried out under subcontract, but especially in repair construction it is done directly for the owner of the property.<BR><BR>Also included are building finishing and building completion activities.<BR><BR>Included is the installation of all kind of utilities that make the construction function as such. These activities are usually performed at the site of the construction, although parts of the job may be carried out in a special shop. Included are activities such as plumbing, installation of heating and air-conditioning systems, antennas, alarm systems and other electrical work, sprinkler systems, elevators and escalators, etc. Also included are insulation work (water, heat, sound), sheet metal work, commercial refrigerating work, the installation of illumination and signalling systems for roads, railways, airports, harbours, etc. Repair of the above mentioned installations is also included.<BR><BR>Building completion activities encompass activities that contribute to the completion or finishing of a construction such as glazing, plastering, painting, floor and wall tiling or covering with other materials like parquet, carpets, wallpaper, etc., floor sanding, finish carpentry, acoustical work, cleaning of the exterior, etc. Repairs to the above mentioned completion or finishing work are also included.<BR><BR>The renting of equipment with operator is classified with the associated construction activity.",
+    "includes": [],
+    "excludes": []
+  }
+}
+```
+
+## SIC_LOOKUP_SIMILARITY
+
+SIC similarity lookup
+
+Command run:
+
+```bash
+curl -sS -m 120 -X GET "http://localhost:8080/v1/survey-assist/sic-lookup?description=electrical&similarity=true"
+```
+
+Result: HTTP `200` in `0.008356` seconds
+
+Response body:
+
+```json
+{
+  "description": "electrical",
+  "code": null,
+  "code_meta": null,
+  "code_division": null,
+  "code_division_meta": null,
+  "potential_matches": {
+    "descriptions_count": 278,
+    "descriptions": [
+      "domestic heating and cooking appliances (non-electrical)",
+      "basic electrical equipment and machinery",
+      "batteries, accumulators and industrial electrical equipment",
+      "electrical instruments and appliances for measuring, checking, testing and navigating",
+      "electrical measuring equipment, radio etc",
+      "motor vehicle parts (except electrical, glass or rubber)",
+      "non-electrical measuring, checking and precision instruments and apparatus",
+      "motor vehicle repair and maintenance (including body work and electrical)",
+      "radios, record players etc, electrical goods and appliances (not rental)",
+      "electrical and mechanical engineers",
+      "general mechanical and electrical engineering services",
+      "electrical motor rewinds",
+      "manufacture of electrical transformers",
+      "manufacture of electrical transformers using copper steel",
+      "electrical control gear manufacture",
+      "electrical switchgear manufacture",
+      "manufacture of electrical switchboards",
+      "manufacture of medium high voltage electrical switchgear and protection products",
+      "repair of electrical switch gear",
+      "manufacture of electrical distribution equipment",
+      "optical fibre and electrical cable manufacturer",
+      "manufacture automotive electrical equipment",
+      "manufacture maintenance and installation of electrical equipment",
+      "manufacture of electrical emergency and fire alarm equipment",
+      "distribution and manufacture of electrical and electronic components",
+      "manufacturing electrical test equipment",
+      "calibration and repair of mechanical and electrical measuring instrumentation",
+      "assembly of electrical control panels",
+      "manufacturer of industrial process electrical control panels",
+      "distribution of electrical energy",
+      "civil engineering construction and installation of electrical cables and fitters",
+      "construction electrical contracting",
+      "domestic and commercial electrical contractors",
+      "domestic and industrial electrical contractor",
+      "electrical contracting and engineering",
+      "electrical contracting and maintenance",
+      "electrical contracting and repairs",
+      "electrical contracting cable jointing",
+      "electrical contracting industry",
+      "electrical contracting work",
+      "electrical contractor",
+      "electrical contractors and engineers",
+      "electrical contractors and retailers",
+      "electrical contractors and wholesalers",
+      "electrical contractors for the exhibition industry",
+      "electrical engineering",
+      "electrical fitter",
+      "electrical installation contracting",
+      "electrical installation contractors",
+      "electrical contractor and shop fitting contractor",
+      "electrical installers",
+      "electrical maintenance",
+      "electrical services",
+      "electrical subcontractors",
+      "electrical wiring",
+      "electrical wiring and fittings",
+      "electrical work",
+      "electrical installation contractors computer and data cabling installers",
+      "general electrical contractor maintenance",
+      "installation and testing of electrical wiring and fittings",
+      "installation of electrical building services",
+      "installation of electrical cctv equipment",
+      "installation of electrical equipment cables and troughing",
+      "installation of electrical wiring",
+      "installation of electrical wiring and fittings control systems motor rewinds",
+      "installation of electrical wiring fittings and electrical maintenance",
+      "maintenance installation of electrical equipment",
+      "rewiring and electrical fittings in new houses",
+      "installation and maintenance of security systems electrical contracting",
+      "auto electrical engineers",
+      "auto electrical repairs",
+      "auto electrical services",
+      "auto electrical specialists",
+      "auto electrical and fuel injection specialists",
+      "car electrical repairs",
+      "motor vehicle repairs mechanical and electrical",
+      "auto electrical distributors vehicle bulbs cable terminal accessories",
+      "electrical and plumbing contractors",
+      "electrical plumbing and heating contractors",
+      "gas and electrical engineer including technical testing and analysis",
+      "heating and electrical engineers",
+      "plumbing heating electrical",
+      "distributor of electrical household appliances",
+      "household electrical and electronic distributors",
+      "wholesale distributor of domestic electrical goods",
+      "wholesale of electrical household appliances",
+      "wholesale of electrical household goods to retail outlets",
+      "wholesale of radio television and electrical household appliances",
+      
+... (truncated)
+```
+
+## SIC_LOOKUP_EMPTY
+
+SIC lookup validation error path (expected 400)
+
+Command run:
+
+```bash
+curl -sS -m 120 -X GET "http://localhost:8080/v1/survey-assist/sic-lookup?description=&similarity=false"
+```
+
+Result: HTTP `400` in `0.000886` seconds
+
+Response body:
+
+```json
+{
+  "detail": "Description cannot be empty"
+}
+```
+
+## SIC_LOOKUP_UNKNOWN
+
+SIC lookup unknown description path
+
+Command run:
+
+```bash
+curl -sS -m 120 -X GET "http://localhost:8080/v1/survey-assist/sic-lookup?description=zzzxxyyqq&similarity=false"
+```
+
+Result: HTTP `200` in `0.001308` seconds
+
+Response body:
+
+```json
+{
+  "description": "zzzxxyyqq",
+  "code": null,
+  "code_meta": null,
+  "code_division": null,
+  "code_division_meta": null
+}
+```
+
+## SOC_LOOKUP_EXACT
+
+SOC exact lookup
+
+Command run:
+
+```bash
+curl -sS -m 120 -X GET "http://localhost:8080/v1/survey-assist/soc-lookup?description=zoologist&similarity=false"
+```
+
+Result: HTTP `200` in `0.000777` seconds
+
+Response body:
+
+```json
+{
+  "description": "zoologist",
+  "code": "2112",
+  "code_meta": {
+    "code": "2112",
+    "group_title": "Biological scientists",
+    "group_description": "Biological scientists research living organisms and biological systems.",
+    "entry_routes_and_quals": "Usually requires a relevant scientific degree.",
+    "tasks": [
+      "Design and conduct research",
+      "Analyse biological data"
+    ]
+  },
+  "code_major_group": "2",
+  "code_major_group_meta": {
+    "code": "2",
+    "group_title": "Professional occupations",
+    "group_description": "Occupations requiring high levels of specialist knowledge and professional expertise.",
+    "entry_routes_and_quals": "",
+    "tasks": []
+  }
+}
+```
+
+## SOC_LOOKUP_SIMILARITY
+
+SOC similarity lookup (no exact match; returns ranked description matches). Use a non-IT query term in examples and recorded output.
+
+Command run:
+
+```bash
+curl -sS -m 120 -X GET "http://localhost:8080/v1/survey-assist/soc-lookup?description=nurse&similarity=true"
+```
+
+Result: HTTP `200` (timing varies with lookup data)
+
+Response body (abbreviated; full list omitted):
+
+```json
+{
+  "description": "nurse",
+  "code": null,
+  "code_meta": null,
+  "code_major_group": null,
+  "code_major_group_meta": null,
+  "potential_matches": {
+    "descriptions_count": 42,
+    "descriptions": [
+      "staff nurse",
+      "registered nurse",
+      "nurse practitioner",
+      "community nurse",
+      "mental health nurse"
+    ],
+    "codes_count": 0,
+    "codes": [],
+    "major_groups_count": 0,
+    "major_groups": []
+  }
+}
+```
+
+Re-run against your `SOC_LOOKUP_DATA_PATH` CSV and paste a short sample of `potential_matches.descriptions` if you need a recorded snapshot. Keep examples in sectors such as health, education, or agriculture—not IT job titles.
+
+## SOC_LOOKUP_EMPTY
+
+SOC lookup validation error path (expected 400)
+
+Command run:
+
+```bash
+curl -sS -m 120 -X GET "http://localhost:8080/v1/survey-assist/soc-lookup?description=&similarity=false"
+```
+
+Result: HTTP `400` in `0.000730` seconds
+
+Response body:
+
+```json
+{
+  "detail": "Description cannot be empty"
+}
+```
+
+## SOC_VS_STATUS
+
+SOC vector store readiness (port **8089**)
+
+Command run:
+
+```bash
+curl -sS -m 120 -X GET "http://localhost:8089/v1/soc-vector-store/status"
+```
+
+Result: HTTP `200` in `0.010458` seconds (2026-05-19)
+
+Response body (abbreviated):
+
+```json
+{
+  "status": "ready",
+  "embedding_model_name": "all-MiniLM-L6-v2",
+  "db_dir": "src/soc_classification_vector_store/data/vector_store",
+  "index_size": 32773,
+  "matches": 20
+}
+```
+
+## SOC_LOOKUP_UNKNOWN
+
+SOC lookup unknown description path (expected **404**)
+
+Command run:
+
+```bash
+curl -sS -m 120 -X GET "http://localhost:8080/v1/survey-assist/soc-lookup?description=zzzxxyyqq&similarity=false"
+```
+
+Result: HTTP `404` in `0.000602` seconds (2026-05-19)
+
+Response body:
+
+```json
+{
+  "detail": "No SOC code found for description: zzzxxyyqq"
+}
+```
+
+Legacy note: an earlier runbook recorded HTTP `200` with `code: null`. Current API returns `404` when no code matches.
+
+## CLASSIFY_SIC_DEFAULT
+
+SIC classify default options
+
+Command run:
+
+```bash
+curl -sS -m 120 -X POST "http://localhost:8080/v1/survey-assist/classify" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "llm": "gemini",
+  "type": "sic",
+  "job_title": "Electrician",
+  "job_description": "Installing and maintaining electrical systems",
+  "org_description": "Electrical contracting company"
+}'
+```
+
+Result: HTTP `200` in `5.253597` seconds
+
+Response body:
+
+```json
+{
+  "requested_type": "sic",
+  "results": [
+    {
+      "type": "sic",
+      "classified": true,
+      "followup": null,
+      "code": "43210",
+      "description": "Electrical installation",
+      "candidates": [
+        {
+          "code": "43210",
+          "descriptive": "Electrical work and wiring",
+          "likelihood": 0.99
+        },
+        {
+          "code": "46150",
+          "descriptive": "Household goods sales agent",
+          "likelihood": 0.1
+        },
+        {
+          "code": "35140",
+          "descriptive": "Power charging services",
+          "likelihood": 0.1
+        },
+        {
+          "code": "52290",
+          "descriptive": "Other transport support",
+          "likelihood": 0.1
+        },
+        {
+          "code": "29310",
+          "descriptive": "Car electronics manufacturing",
+          "likelihood": 0.1
+        }
+      ],
+      "reasoning": "The respondent data clearly states 'Electrical contracting company' as the main activity and 'Installing and maintaining electrical systems' as the job description. SIC code 43210, 'Electrical installation', directly matches these descriptions, with 'Electrical contractor (construction)' and 'Electrical installation' listed as example activities. The other codes in the shortlist are not relevant to electrical contracting or installation services. Therefore, there is a very high confidence that 43210 is the correct and unambiguous classification."
+    }
+  ]
+}
+```
+
+## CLASSIFY_SIC_REPHRASE_FALSE
+
+SIC classify with SIC rephrase disabled
+
+Command run:
+
+```bash
+curl -sS -m 120 -X POST "http://localhost:8080/v1/survey-assist/classify" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "llm": "gemini",
+  "type": "sic",
+  "job_title": "Electrician",
+  "job_description": "Installing and maintaining electrical systems",
+  "org_description": "Electrical contracting company",
+  "options": {
+    "sic": {
+      "rephrased": false
+    }
+  }
+}'
+```
+
+Result: HTTP `200` in `5.181986` seconds
+
+Response body:
+
+```json
+{
+  "requested_type": "sic",
+  "results": [
+    {
+      "type": "sic",
+      "classified": true,
+      "followup": null,
+      "code": "43210",
+      "description": "Electrical installation",
+      "candidates": [
+        {
+          "code": "43210",
+          "descriptive": "Electrical installation",
+          "likelihood": 0.99
+        },
+        {
+          "code": "46150",
+          "descriptive": "Agents involved in the sale of furniture, household goods, hardware and ironmongery",
+          "likelihood": 0.1
+        },
+        {
+          "code": "35140",
+          "descriptive": "Trade of electricity",
+          "likelihood": 0.1
+        },
+        {
+          "code": "52290",
+          "descriptive": "Other transportation support activities",
+          "likelihood": 0.1
+        },
+        {
+          "code": "29310",
+          "descriptive": "Manufacture of electrical and electronic equipment for motor vehicles",
+          "likelihood": 0.1
+        }
+      ],
+      "reasoning": "The respondent data clearly states 'Electrical contracting company' as the main activity and 'Installing and maintaining electrical systems' as the job description. SIC code 43210, 'Electrical installation', directly matches these descriptions, with 'Electrical contractor (construction)' and 'Electrical installation' listed as example activities. The other codes in the shortlist are not relevant to electrical contracting or installation services. Therefore, there is a very high confidence that 43210 is the correct and unambiguous classification."
+    }
+  ],
+  "meta": {
+    "llm": "gemini",
+    "applied_options": {
+      "sic": {
+        "rephrased": false
+      },
+      "soc": {}
+    }
+  }
+}
+```
+
+## CLASSIFY_SOC_UNAMBIGUOUS
+
+SA-693 acceptance case: farm hand → codable unit **9111** via `unambiguous_soc_code` only (no `formulate_open_question`).
+
+Command run:
+
+```bash
+curl -sS -m 120 -X POST "http://localhost:8080/v1/survey-assist/classify" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "llm": "gemini",
+  "type": "soc",
+  "job_title": "farm hand",
+  "job_description": "Manual labour under supervision that requires basic routine tasks only. All of my tasks require minimal training.",
+  "org_description": "farming",
+  "options": {
+    "soc": {
+      "rephrased": false
+    }
+  }
+}'
+```
+
+**Expected (SA-693):** HTTP `200`; `results[0].classified` `true`; `code` `"9111"`; `followup` `null`; `candidates` includes `9111` with highest likelihood.
+
+**Recorded:** Re-run after `poetry install` (path `../soc-classification-utils`), API restart, and `gcloud auth application-default login`. Optional snapshot: `SA-693-soc-curl-results.json`. Prior SA-673 runs: `SA-673-local-api-test-results.md`.
+
+---
+
+## CLASSIFY_SOC_AMBIGUOUS
+
+SA-693 ambiguous path: `unambiguous_soc_code` returns `codable: false`, then `formulate_open_question` sets `followup`.
+
+Command run:
+
+```bash
+curl -sS -m 120 -X POST "http://localhost:8080/v1/survey-assist/classify" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "llm": "gemini",
+  "type": "soc",
+  "job_title": "Finance manager",
+  "job_description": "Manages budgets, financial reporting and planning for a company",
+  "org_description": "Financial services company",
+  "options": {
+    "soc": {
+      "rephrased": false
+    }
+  }
+}'
+```
+
+**Expected (SA-693):** HTTP `200`; `classified` `false`; `code` and `description` `null`; non-empty `followup`; `candidates` from first LLM step.
+
+**Recorded (2026-05-19):** This payload often still returns `classified: true` from step 1 only (for example `code: "1131"`). Do not treat a finance-manager pass as proof of step 2. For a confirmed live step-2 run, use the vague Worker example in the caveat under **SA-693 acceptance checks**, or check API logs for `LLM request sent to formulate open question (SOC)`.
+
+---
+
+## CLASSIFY_SOC_DEFAULT
+
+SOC classify with default options (SOC rephrase **enabled** when `options` omitted).
+
+Command run:
+
+```bash
+curl -sS -m 120 -X POST "http://localhost:8080/v1/survey-assist/classify" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "llm": "gemini",
+  "type": "soc",
+  "job_title": "Farm worker",
+  "job_description": "General labour work on a farm",
+  "org_description": "Agricultural business"
+}'
+```
+
+**Expected:** HTTP `200`; two-step classify; `meta.applied_options.soc.rephrased` true (or equivalent default).
+
+**Recorded:** Re-run with SA-693 script.
+
+---
+
+## CLASSIFY_SOC_REPHRASE_FALSE
+
+SOC classify with SOC rephrase disabled (two-step SA-693 flow)
+
+Command run:
+
+```bash
+curl -sS -m 120 -X POST "http://localhost:8080/v1/survey-assist/classify" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "llm": "gemini",
+  "type": "soc",
+  "job_title": "Finance manager",
+  "job_description": "Manages budgets, financial reporting and planning for a company",
+  "org_description": "Financial services company",
+  "options": {
+    "soc": {
+      "rephrased": false
+    }
+  }
+}'
+```
+
+Result: HTTP `200` in `5.130867` seconds
+
+Response body:
+
+```json
+{
+  "requested_type": "soc",
+  "results": [
+    {
+      "type": "soc",
+      "classified": false,
+      "followup": "Does the Finance Manager primarily manage a team of finance professionals, or are their responsibilities more focused on the direct execution of financial tasks and reporting?",
+      "code": null,
+      "description": null,
+      "candidates": [
+        {
+          "code": "1131",
+          "descriptive": "Managers directors and senior officials",
+          "likelihood": 0.8
+        },
+        {
+          "code": "3534",
+          "descriptive": "Associate professional and technical occupations",
+          "likelihood": 0.6
+        }
+      ],
+      "reasoning": "The job title 'Finance manager' directly matches an example job title for SOC code 1131, 'Managers directors and senior officials'. The job description 'Manages budgets, financial reporting and planning for a company' also aligns well with the responsibilities of a manager. However, without further clarification on whether this role involves managing a team or is more focused on individual contributor tasks, there is a possibility it could fall under 'Associate professional and technical occupations' (3534), which includes 'Financial accounts manager'. The confidence for 1131 is higher due to the direct title match, but a follow-up question is needed to distinguish between a managerial role with direct reports and a senior individual contributor role."
+    }
+  ],
+  "meta": {
+    "llm": "gemini",
+    "applied_options": {
+      "sic": {},
+      "soc": {
+        "rephrased": false
+      }
+    }
+  }
+}
+```
+
+## CLASSIFY_SOC_REPHRASE_TRUE
+
+SOC classify with SOC rephrase enabled (two-step SA-693 flow)
+
+Command run:
+
+```bash
+curl -sS -m 120 -X POST "http://localhost:8080/v1/survey-assist/classify" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "llm": "gemini",
+  "type": "soc",
+  "job_title": "Finance manager",
+  "job_description": "Manages budgets, financial reporting and planning for a company",
+  "org_description": "Financial services company",
+  "options": {
+    "soc": {
+      "rephrased": true
+    }
+  }
+}'
+```
+
+Result: HTTP `200` in `11.158323` seconds
+
+Response body:
+
+```json
+{
+  "requested_type": "soc",
+  "results": [
+    {
+      "type": "soc",
+      "classified": false,
+      "followup": "Does the Finance Manager primarily manage a team of finance professionals, or are their responsibilities more focused on the direct execution of financial tasks and reporting?",
+      "code": null,
+      "description": null,
+      "candidates": [
+        {
+          "code": "1131",
+          "descriptive": "Managers directors and senior officials",
+          "likelihood": 0.8
+        },
+        {
+          "code": "3534",
+          "descriptive": "Associate professional and technical occupations",
+          "likelihood": 0.6
+        }
+      ],
+      "reasoning": "The job title 'Finance manager' directly matches an example job title for SOC code 1131, 'Managers directors and senior officials'. The job description 'Manages budgets, financial reporting and planning for a company' also aligns well with the responsibilities of a manager. However, without further clarification on whether this role involves managing a team or is more focused on individual contributor tasks, there is a possibility it could fall under 'Associate professional and technical occupations' (3534), which includes 'Financial accounts manager'. The confidence for 1131 is higher due to the direct title match, but a follow-up question is needed to distinguish between a managerial role with direct reports and a senior individual contributor role."
+    }
+  ],
+  "meta": {
+    "llm": "gemini",
+    "applied_options": {
+      "sic": {},
+      "soc": {
+        "rephrased": true
+      }
+    }
+  }
+}
+```
+
+## CLASSIFY_SIC_SOC
+
+Combined SIC+SOC classify flow (SOC leg: two-step SA-693; SIC leg unchanged).
+
+**Out of scope for SOC-only local runs:** requires **SIC vector store** on port **8088** (`make run-vector-store` in `sic-classification-vector-store`) in addition to SOC on **8089**. Skip this section when testing SA-693 with SOC only.
+
+Command run:
+
+```bash
+curl -sS -m 120 -X POST "http://localhost:8080/v1/survey-assist/classify" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "llm": "gemini",
+  "type": "sic_soc",
+  "job_title": "Primary school teacher",
+  "job_description": "Teaching maths and English to children aged 5-11",
+  "org_description": "Primary school"
+}'
+```
+
+Result: HTTP `200` in `10.730952` seconds
+
+Response body:
+
+```json
+{
+  "requested_type": "sic_soc",
+  "results": [
+    {
+      "type": "sic",
+      "classified": true,
+      "followup": null,
+      "code": "85200",
+      "description": "Primary education",
+      "candidates": [
+        {
+          "code": "85200",
+          "descriptive": "Primary education",
+          "likelihood": 0.99
+        },
+        {
+          "code": "85310",
+          "descriptive": "Secondary education",
+          "likelihood": 0.01
+        },
+        {
+          "code": "41201",
+          "descriptive": "Commercial building construction",
+          "likelihood": 0.01
+        },
+        {
+          "code": "85100",
+          "descriptive": "Early years education",
+          "likelihood": 0.01
+        },
+        {
+          "code": "85590",
+          "descriptive": "Other education",
+          "likelihood": 0.01
+        }
+      ],
+      "reasoning": "The company's main activity is 'Primary school' and the job title is 'Primary school teacher' with a description of 'Teaching maths and English to children aged 5-11'. This directly aligns with SIC code 85200 'Primary education', which includes 'Primary schools' as an example activity. The age range of 5-11 is characteristic of primary education. Other codes are clearly less relevant: 85310 is for secondary education, 41201 is for construction, 85100 is for pre-primary education, and 85590 is a residual category for other education not elsewhere classified, which is not applicable given the direct match. Therefore, 85200 can be assigned with high confidence."
+    },
+    {
+      "type": "soc",
+      "classified": false,
+      "followup": "Could you clarify if your role involves teaching children within the primary school age range (typically 5-11 years old) or if you are involved in early years education (pre-school/kindergarten)?",
+      "code": null,
+      "description": null,
+      "candidates": [
+        {
+          "code": "2314",
+          "descriptive": "Primary education teaching professionals",
+          "likelihood": 0.9
+        },
+        {
+          "code": "6111",
+          "descriptive": "Caring leisure and other service occupations",
+          "likelihood": 0.2
+        },
+        {
+          "code": "2315",
+          "descriptive": "Professional occupations",
+          "likelihood": 0.2
+        }
+      ],
+      "reasoning": "The company's main activity is 'Primary school' and the job title is 'Primary school teacher', which directly matches SOC code 2314 'Primary education teaching professionals'. The job description 'Teaching maths and English to children aged 5-11' further supports this. However, the provided SOC subset also includes 'Kindergarten teacher' (6111) and 'Early years teacher' (2315) which can sometimes overlap with the lower end of primary school age ranges. While 2314 is the most likely, a follow-up question would help to definitively rule out early years roles if there's any ambiguity in the age range '5-11' and how it aligns with specific educational stages in the UK."
+    }
+  ]
+}
+```
+
+## CLASSIFY_INVALID_TYPE
+
+Classification payload validation failure (expected 422)
+
+Command run:
+
+```bash
+curl -sS -m 120 -X POST "http://localhost:8080/v1/survey-assist/classify" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "llm": "gemini",
+  "type": "foo",
+  "job_title": "Tester",
+  "job_description": "Invalid type check",
+  "org_description": "Test org"
+}'
+```
+
+Result: HTTP `422` in `0.001463` seconds
+
+Response body:
+
+```json
+{
+  "detail": [
+    {
+      "type": "enum",
+      "loc": [
+        "body",
+        "type"
+      ],
+      "msg": "Input should be 'sic', 'soc' or 'sic_soc'",
+      "input": "foo",
+      "ctx": {
+        "expected": "'sic', 'soc' or 'sic_soc'"
+      }
+    }
+  ]
+}
+```

--- a/api/main.py
+++ b/api/main.py
@@ -39,8 +39,7 @@ async def lifespan(fastapi_app: FastAPI):
     fastapi_app.state.gemini_llm = ClassificationLLM(model_name="gemini-2.5-flash")
 
     # SOC classification LLM (two-step: unambiguous_soc_code, then formulate_open_question)
-    soc_model = os.getenv("SOC_LLM_MODEL", "gemini-2.5-flash")
-    fastapi_app.state.soc_llm = SOCClassificationLLM(model_name=soc_model)
+    fastapi_app.state.soc_llm = SOCClassificationLLM(model_name="gemini-2.5-flash")
 
     # Initialise Firestore client (if configured)
     init_firestore_client()

--- a/api/main.py
+++ b/api/main.py
@@ -10,16 +10,9 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi_swagger2 import FastAPISwagger2
 from industrial_classification_utils.llm.llm import ClassificationLLM
-
-try:
-    from occupational_classification_utils.llm.llm import (
-        ClassificationLLM as SOCClassificationLLM,
-    )
-
-    SOC_LLM_AVAILABLE = True
-except ImportError:
-    SOCClassificationLLM = None  # type: ignore[misc, assignment]
-    SOC_LLM_AVAILABLE = False
+from occupational_classification_utils.llm.llm import (
+    ClassificationLLM as SOCClassificationLLM,
+)
 
 from api.routes.v1.classify import router as classify_router
 from api.routes.v1.config import router as config_router
@@ -46,11 +39,8 @@ async def lifespan(fastapi_app: FastAPI):
     fastapi_app.state.gemini_llm = ClassificationLLM(model_name="gemini-2.5-flash")
 
     # SOC classification LLM (two-step: unambiguous_soc_code, then formulate_open_question)
-    if SOC_LLM_AVAILABLE and SOCClassificationLLM is not None:
-        soc_model = os.getenv("SOC_LLM_MODEL", "gemini-2.5-flash")
-        fastapi_app.state.soc_llm = SOCClassificationLLM(model_name=soc_model)
-    else:
-        fastapi_app.state.soc_llm = None
+    soc_model = os.getenv("SOC_LLM_MODEL", "gemini-2.5-flash")
+    fastapi_app.state.soc_llm = SOCClassificationLLM(model_name=soc_model)
 
     # Initialise Firestore client (if configured)
     init_firestore_client()

--- a/api/main.py
+++ b/api/main.py
@@ -45,7 +45,7 @@ async def lifespan(fastapi_app: FastAPI):
     # Startup
     fastapi_app.state.gemini_llm = ClassificationLLM(model_name="gemini-2.5-flash")
 
-    # SOC classification LLM (single-step RAG; short_list from vector store)
+    # SOC classification LLM (two-step: unambiguous_soc_code, then formulate_open_question)
     if SOC_LLM_AVAILABLE and SOCClassificationLLM is not None:
         soc_model = os.getenv("SOC_LLM_MODEL", "gemini-2.5-flash")
         fastapi_app.state.soc_llm = SOCClassificationLLM(model_name=soc_model)

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -127,6 +127,7 @@ async def classify_text(
     sic_vector_store: SICVectorStoreClient = sic_vector_store_dependency,
     soc_vector_store: SOCVectorStoreClient = soc_vector_store_dependency,
     rephrase_client: SICRephraseClient = rephrase_dependency,
+    soc_rephrase_client: SOCRephraseClient = soc_rephrase_dependency,
 ) -> Union[GenericClassificationResponse, GenericClassificationResponseWithoutMeta]:
     """Classify the provided text using the generic response format.
 
@@ -136,6 +137,7 @@ async def classify_text(
         sic_vector_store (SICVectorStoreClient): SIC vector store client instance.
         soc_vector_store (SOCVectorStoreClient): SOC vector store client instance.
         rephrase_client (SICRephraseClient): SIC rephrase client instance.
+        soc_rephrase_client (SOCRephraseClient): SOC rephrase client instance.
 
     Returns:
         GenericClassificationResponse: A response containing the classification results in
@@ -188,7 +190,11 @@ async def classify_text(
         # Handle SOC classification
         if classification_request.type in ["soc", "sic_soc"]:
             soc_result = await _classify_soc(
-                request, classification_request, soc_vector_store, body_id
+                request,
+                classification_request,
+                soc_vector_store,
+                soc_rephrase_client,
+                body_id,
             )
             results.append(soc_result)
 
@@ -512,20 +518,11 @@ def _apply_rephrasing(
 
 
 def _apply_soc_rephrasing(
-    result: GenericClassificationResult,
+    candidates: list[GenericCandidate],
     soc_rephrase_client: SOCRephraseClient,
     classification_request: ClassificationRequest,
-) -> GenericClassificationResult:
-    """Apply rephrasing to SOC result and candidates if enabled.
-
-    Args:
-        result: SOC classification result to potentially rephrase.
-        soc_rephrase_client: The SOC rephrase client instance.
-        classification_request: The classification request containing options.
-
-    Returns:
-        GenericClassificationResult with rephrased descriptions if enabled.
-    """
+) -> list[GenericCandidate]:
+    """Apply rephrasing to SOC candidates if enabled (mirrors ``_apply_rephrasing``)."""
     rephrasing_enabled = (
         classification_request.options.soc.rephrased
         if classification_request.options and classification_request.options.soc
@@ -533,21 +530,12 @@ def _apply_soc_rephrasing(
     )
 
     if not rephrasing_enabled:
-        return result
+        return candidates
 
     try:
-        # Rephrase main SOC description if possible
-        if result.code:
-            rephrased_main = soc_rephrase_client.get_rephrased_description(result.code)
-            if rephrased_main:
-                result.description = rephrased_main
-
-        # Rephrase SOC candidates
-        rephrased_candidates: list[GenericCandidate] = []
-        for candidate in result.candidates or []:
-            rephrased_text = soc_rephrase_client.get_rephrased_description(
-                candidate.code
-            )
+        rephrased_candidates = []
+        for candidate in candidates:
+            rephrased_text = soc_rephrase_client.get_rephrased_description(candidate.code)
             if rephrased_text:
                 rephrased_candidates.append(
                     GenericCandidate(
@@ -557,19 +545,22 @@ def _apply_soc_rephrasing(
                     )
                 )
             else:
+                logger.debug(
+                    f"No rephrased description found for SOC code {candidate.code}, "
+                    "keeping original description"
+                )
                 rephrased_candidates.append(candidate)
-
-        result.candidates = rephrased_candidates
-        return result
+        return rephrased_candidates
     except Exception as e:  # pylint: disable=broad-except
-        logger.warning(f"Failed to rephrase SOC classification result: {e}")
-        return result
+        logger.warning(f"Failed to rephrase SOC candidates: {e}")
+        return candidates
 
 
 async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
     request: Request,
     classification_request: ClassificationRequest,
     vector_store: SOCVectorStoreClient,
+    soc_rephrase_client: SOCRephraseClient,
     body_id: str,
 ) -> GenericClassificationResult:
     """Classify using SOC classification with two-step process (mirrors ``_classify_sic``).
@@ -578,6 +569,7 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
         request (Request): The FastAPI request object.
         classification_request (ClassificationRequest): The classification request.
         vector_store (SOCVectorStoreClient): SOC vector store client.
+        soc_rephrase_client (SOCRephraseClient): SOC rephrase client.
         body_id (str): Pseudo correlation ID built from truncated request fields.
 
     Returns:
@@ -738,26 +730,10 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
                 reasoning=unambiguous_response.reasoning,
             )
 
-        # Apply rephrasing if enabled (behaviour unchanged from pre-SA-693)
-        soc_rephrase_client = getattr(request.app.state, "soc_rephrase_client", None)
-        if soc_rephrase_client and (result.code or result.candidates):
-            result = _apply_soc_rephrasing(
-                result, soc_rephrase_client, classification_request
-            )
-            logger.info(
-                "SOC rephrasing applied",
-                body_id=body_id,
-                has_rephrase_client=str(soc_rephrase_client is not None),
-                rephrased_candidates_count=str(len(result.candidates or [])),
-            )
-        elif (
-            classification_request.options
-            and classification_request.options.soc
-            and classification_request.options.soc.rephrased
-        ):
-            logger.info(
-                "SOC rephrasing requested but SOCRephraseClient not available",
-                body_id=body_id,
+        # Apply rephrasing if enabled (mirrors SIC: candidates only)
+        if soc_rephrase_client and candidates:
+            result.candidates = _apply_soc_rephrasing(
+                candidates, soc_rephrase_client, classification_request
             )
 
         return result

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -631,18 +631,6 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
             for result in search_results
         ]
 
-        if not short_list:
-            logger.warning("SOC vector store returned no results", body_id=body_id)
-            return GenericClassificationResult(
-                type="soc",
-                classified=False,
-                followup=None,
-                code=None,
-                description=None,
-                candidates=[],
-                reasoning="No SOC candidates returned from vector store search.",
-            )
-
         # Step 1: Call unambiguous SOC code classification
         logger.info(
             f"LLM request sent for unambiguous SOC classification - "

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -7,7 +7,7 @@ vector store and LLM.
 
 import os
 import time
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from industrial_classification_utils.llm.llm import ClassificationLLM
@@ -447,7 +447,7 @@ async def _classify_sic(  # pylint: disable=unused-argument,too-many-locals
         # Apply rephrasing if enabled
         if rephrase_client and candidates:
             result.candidates = _apply_rephrasing(
-                candidates, rephrase_client, classification_request
+                candidates, rephrase_client, classification_request, "sic"
             )
 
         return result
@@ -471,25 +471,29 @@ async def _classify_sic(  # pylint: disable=unused-argument,too-many-locals
 
 def _apply_rephrasing(
     candidates: list[GenericCandidate],
-    rephrase_client: SICRephraseClient,
+    rephrase_client: SICRephraseClient | SOCRephraseClient,
     classification_request: ClassificationRequest,
+    classification_type: Literal["sic", "soc"],
 ) -> list[GenericCandidate]:
-    """Apply rephrasing to SIC candidates if enabled.
+    """Apply rephrasing to classification candidates when enabled in request options.
 
     Args:
-        candidates: List of SIC candidates to potentially rephrase.
-        rephrase_client: The rephrase client instance.
+        candidates: Candidates to potentially rephrase.
+        rephrase_client: SIC or SOC rephrase client (both expose get_rephrased_description).
         classification_request: The classification request containing options.
+        classification_type: ``sic`` or ``soc`` — selects which options.rephrased flag to read.
 
     Returns:
         List of candidates with rephrased descriptions if enabled.
     """
-    # Check if SIC rephrasing is enabled (default to True for backward compatibility)
-    rephrasing_enabled = (
-        classification_request.options.sic.rephrased
-        if classification_request.options and classification_request.options.sic
-        else True
-    )
+    type_label = classification_type.upper()
+    if classification_request.options:
+        type_options = getattr(classification_request.options, classification_type, None)
+        rephrasing_enabled = (
+            type_options.rephrased if type_options is not None else True
+        )
+    else:
+        rephrasing_enabled = True
 
     if not rephrasing_enabled:
         return candidates
@@ -507,54 +511,14 @@ def _apply_rephrasing(
                     )
                 )
             else:
-                # Keep original description if no rephrased version available
                 logger.debug(
-                    f"No rephrased description found for SIC code {candidate.code}, "
-                    "keeping original description"
+                    f"No rephrased description found for {type_label} code "
+                    f"{candidate.code}, keeping original description"
                 )
                 rephrased_candidates.append(candidate)
         return rephrased_candidates
     except Exception as e:  # pylint: disable=broad-except
-        logger.warning(f"Failed to rephrase SIC candidates: {e}")
-        return candidates
-
-
-def _apply_soc_rephrasing(
-    candidates: list[GenericCandidate],
-    soc_rephrase_client: SOCRephraseClient,
-    classification_request: ClassificationRequest,
-) -> list[GenericCandidate]:
-    """Apply rephrasing to SOC candidates if enabled (mirrors ``_apply_rephrasing``)."""
-    rephrasing_enabled = (
-        classification_request.options.soc.rephrased
-        if classification_request.options and classification_request.options.soc
-        else True
-    )
-
-    if not rephrasing_enabled:
-        return candidates
-
-    try:
-        rephrased_candidates = []
-        for candidate in candidates:
-            rephrased_text = soc_rephrase_client.get_rephrased_description(candidate.code)
-            if rephrased_text:
-                rephrased_candidates.append(
-                    GenericCandidate(
-                        code=candidate.code,
-                        descriptive=rephrased_text,
-                        likelihood=candidate.likelihood,
-                    )
-                )
-            else:
-                logger.debug(
-                    f"No rephrased description found for SOC code {candidate.code}, "
-                    "keeping original description"
-                )
-                rephrased_candidates.append(candidate)
-        return rephrased_candidates
-    except Exception as e:  # pylint: disable=broad-except
-        logger.warning(f"Failed to rephrase SOC candidates: {e}")
+        logger.warning(f"Failed to rephrase {type_label} candidates: {e}")
         return candidates
 
 
@@ -732,10 +696,10 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
                 reasoning=unambiguous_response.reasoning,
             )
 
-        # Apply rephrasing if enabled (mirrors SIC: candidates only)
+        # Apply rephrasing if enabled
         if soc_rephrase_client and candidates:
-            result.candidates = _apply_soc_rephrasing(
-                candidates, soc_rephrase_client, classification_request
+            result.candidates = _apply_rephrasing(
+                candidates, soc_rephrase_client, classification_request, "soc"
             )
 
         return result

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -643,7 +643,7 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
                     "error": {
                         "type": "classification_error",
                         "message": "The LLM could not generate a valid classification",
-                        "details": f"Unambiguous SOC classification failed: {e!s}",
+                        "details": f"Unambiguous classification failed: {e!s}",
                     }
                 },
             ) from e

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -102,12 +102,8 @@ def get_sic_llm_client(model_name: Optional[str] = None) -> Any:  # type: ignore
 
 
 def get_soc_llm_client(request: Request) -> Any:  # type: ignore
-    """Get the SOC ClassificationLLM from app state (or None if not available).
-
-    Mirrors SIC pattern: LLM is provided via app state (main.py). SOC is optional,
-    so returns None when soc-classification-utils is not installed.
-    """
-    return getattr(request.app.state, "soc_llm", None)
+    """Get the SOC ClassificationLLM from app state (mirrors SIC via gemini_llm)."""
+    return request.app.state.soc_llm
 
 
 # Define dependencies at module level
@@ -588,30 +584,11 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
         GenericClassificationResult: SOC classification result.
 
     Raises:
-        HTTPException: If the two-step process fails with 422 status, or SOC LLM is
-            unavailable (503).
+        HTTPException: If the two-step process fails with 422 status.
     """
     try:
-        # SOC LLM from app state (optional; 503 if soc-classification-utils not loaded).
-        llm = getattr(request.app.state, "soc_llm", None)
-        if llm is None:
-            logger.error(
-                "SOC LLM not available (soc-classification-utils not installed)",
-                body_id=body_id,
-            )
-            raise HTTPException(
-                status_code=503,
-                detail={
-                    "error": {
-                        "type": "service_unavailable",
-                        "message": "SOC classification is not available",
-                        "details": (
-                            "SOC LLM is not configured "
-                            "(soc-classification-utils may not be installed)."
-                        ),
-                    }
-                },
-            )
+        # Get LLM instance (mirrors SIC: request.app.state.gemini_llm)
+        llm = request.app.state.soc_llm
 
         # Get vector store search results
         search_results = await vector_store.search(

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -456,7 +456,11 @@ async def _classify_sic(  # pylint: disable=unused-argument,too-many-locals
         # Re-raise HTTP exceptions as they are already properly formatted
         raise
     except Exception as e:
-        logger.error("Unexpected error in SIC classification", error=str(e))
+        logger.error(
+            "Unexpected error in SIC classification",
+            error=str(e),
+            body_id=body_id,
+        )
         raise HTTPException(
             status_code=422,
             detail={

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -365,6 +365,7 @@ async def _classify_sic(  # pylint: disable=unused-argument,too-many-locals
                 semantic_search_results=short_list,
                 job_title=classification_request.job_title,
                 job_description=classification_request.job_description,
+                correlation_id=body_id,
             )
             llm_duration_ms = int((time.perf_counter() - llm_start) * 1000)
             logger.info(
@@ -437,6 +438,7 @@ async def _classify_sic(  # pylint: disable=unused-argument,too-many-locals
                     job_title=classification_request.job_title,
                     job_description=classification_request.job_description,
                     llm_output=unambiguous_response.alt_candidates,
+                    correlation_id=body_id,
                 )
                 llm_duration2_ms = int((time.perf_counter() - llm_start2) * 1000)
                 logger.info(
@@ -625,6 +627,7 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
                 semantic_search_results=short_list,
                 job_title=classification_request.job_title,
                 job_description=classification_request.job_description,
+                correlation_id=body_id,
             )
             llm_duration_ms = int((time.perf_counter() - llm_start) * 1000)
             logger.info(
@@ -694,6 +697,7 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
                     job_title=classification_request.job_title,
                     job_description=classification_request.job_description,
                     llm_output=unambiguous_response.alt_candidates,
+                    correlation_id=body_id,
                 )
                 llm_duration2_ms = int((time.perf_counter() - llm_start2) * 1000)
                 logger.info(

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -7,6 +7,7 @@ vector store and LLM.
 
 import os
 import time
+from dataclasses import dataclass
 from typing import Any, Literal, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -109,58 +110,50 @@ def get_soc_llm_client(request: Request) -> Any:  # type: ignore
 # Define dependencies at module level
 sic_vector_store_dependency = Depends(get_sic_vector_store_client)
 soc_vector_store_dependency = Depends(get_soc_vector_store_client)
-rephrase_dependency = Depends(get_rephrase_client)
-soc_rephrase_dependency = Depends(get_soc_rephrase_client)
 sic_llm_dependency = Depends(get_sic_llm_client)
 soc_llm_dependency = Depends(get_soc_llm_client)
 
 
-@router.post(
-    "/classify",
-    response_model=Union[
-        GenericClassificationResponse, GenericClassificationResponseWithoutMeta
-    ],
-)
-async def classify_text(
+@dataclass(frozen=True)
+class ClassifyClients:
+    """Vector store and rephrase clients injected into the classify route."""
+
+    sic_vector_store: SICVectorStoreClient
+    soc_vector_store: SOCVectorStoreClient
+    sic_rephrase: SICRephraseClient
+    soc_rephrase: SOCRephraseClient
+
+
+def get_classify_clients(
     request: Request,
-    classification_request: ClassificationRequest,
     sic_vector_store: SICVectorStoreClient = sic_vector_store_dependency,
     soc_vector_store: SOCVectorStoreClient = soc_vector_store_dependency,
-    rephrase_client: SICRephraseClient = rephrase_dependency,
-    soc_rephrase_client: SOCRephraseClient = soc_rephrase_dependency,
-) -> Union[GenericClassificationResponse, GenericClassificationResponseWithoutMeta]:
-    """Classify the provided text using the generic response format.
+) -> ClassifyClients:
+    """Resolve all classify-route clients in one FastAPI dependency."""
+    return ClassifyClients(
+        sic_vector_store=sic_vector_store,
+        soc_vector_store=soc_vector_store,
+        sic_rephrase=get_rephrase_client(request),
+        soc_rephrase=get_soc_rephrase_client(request),
+    )
 
-    Args:
-        request (Request): The FastAPI request object.
-        classification_request (ClassificationRequest): The request containing the text to classify.
-        sic_vector_store (SICVectorStoreClient): SIC vector store client instance.
-        soc_vector_store (SOCVectorStoreClient): SOC vector store client instance.
-        rephrase_client (SICRephraseClient): SIC rephrase client instance.
-        soc_rephrase_client (SOCRephraseClient): SOC rephrase client instance.
 
-    Returns:
-        GenericClassificationResponse: A response containing the classification results in
-        generic format.
+classify_clients_dependency = Depends(get_classify_clients)
 
-    Raises:
-        HTTPException: If the input is invalid or classification fails.
-    """
-    # Validate input
-    start_time = time.perf_counter()
-    body_id = (
+
+def _classify_body_id(classification_request: ClassificationRequest) -> str:
+    """Build a pseudo correlation ID from truncated request fields."""
+    return (
         truncate_identifier(classification_request.job_title)
         + truncate_identifier(classification_request.job_description)
         + truncate_identifier(classification_request.org_description)
     )
-    logger.info(
-        "Request received for classify",
-        type=classification_request.type,
-        body_id=body_id,
-        job_title=truncate_identifier(classification_request.job_title),
-        job_description=truncate_identifier(classification_request.job_description),
-        org_description=truncate_identifier(classification_request.org_description),
-    )
+
+
+def _validate_classify_request(
+    classification_request: ClassificationRequest, body_id: str
+) -> None:
+    """Reject empty job title or description."""
     if (
         not classification_request.job_title.strip()
         or not classification_request.job_description.strip()
@@ -173,80 +166,125 @@ async def classify_text(
             status_code=400, detail="Job title and description cannot be empty"
         )
 
-    results = []
 
-    try:
-        # Handle SIC classification
-        if classification_request.type in ["sic", "sic_soc"]:
-            sic_result = await _classify_sic(
+async def _collect_classify_results(
+    request: Request,
+    classification_request: ClassificationRequest,
+    clients: ClassifyClients,
+    body_id: str,
+) -> list[GenericClassificationResult]:
+    """Run SIC and/or SOC two-step classify flows according to request type."""
+    results: list[GenericClassificationResult] = []
+    req_type = classification_request.type
+
+    if req_type in ("sic", "sic_soc"):
+        results.append(
+            await _classify_sic(
                 request,
                 classification_request,
-                sic_vector_store,
-                rephrase_client,
+                clients.sic_vector_store,
+                clients.sic_rephrase,
                 body_id,
             )
-            results.append(sic_result)
+        )
 
-        # Handle SOC classification
-        if classification_request.type in ["soc", "sic_soc"]:
-            soc_result = await _classify_soc(
+    if req_type in ("soc", "sic_soc"):
+        results.append(
+            await _classify_soc(
                 request,
                 classification_request,
-                soc_vector_store,
-                soc_rephrase_client,
+                clients.soc_vector_store,
+                clients.soc_rephrase,
                 body_id,
             )
-            results.append(soc_result)
+        )
 
-        # Build meta response if options were provided
-        meta = None
-        if classification_request.options:
-            applied_options = AppliedOptions()
+    return results
 
-            # Add SIC options if SIC classification was performed
-            if (
-                classification_request.type in ["sic", "sic_soc"]
-                and classification_request.options.sic
-            ):
-                applied_options.sic = {
-                    "rephrased": classification_request.options.sic.rephrased
-                }
 
-            # Add SOC options if SOC classification was performed
-            if (
-                classification_request.type in ["soc", "sic_soc"]
-                and classification_request.options.soc
-            ):
-                applied_options.soc = {
-                    "rephrased": classification_request.options.soc.rephrased
-                }
+def _build_classify_meta(
+    classification_request: ClassificationRequest,
+) -> ResponseMeta | None:
+    """Build response meta when the client sent options."""
+    if not classification_request.options:
+        return None
 
-            meta = ResponseMeta(
-                llm=classification_request.llm, applied_options=applied_options
-            )
+    applied_options = AppliedOptions()
+    req_type = classification_request.type
 
-        # Build response without meta field if it's None
-        if meta is None:
-            response_obj: Union[
-                GenericClassificationResponse, GenericClassificationResponseWithoutMeta
-            ] = GenericClassificationResponseWithoutMeta(
-                requested_type=classification_request.type,
-                results=results,
-            )
-            duration_ms = int((time.perf_counter() - start_time) * 1000)
-            logger.info(
-                "Response sent for classify",
-                requested_type=classification_request.type,
-                results_count=len(results),
-                body_id=body_id,
-                duration_ms=str(duration_ms),
-            )
-            return response_obj
-        response_obj = GenericClassificationResponse(
+    if req_type in ("sic", "sic_soc") and classification_request.options.sic:
+        applied_options.sic = {
+            "rephrased": classification_request.options.sic.rephrased
+        }
+
+    if req_type in ("soc", "sic_soc") and classification_request.options.soc:
+        applied_options.soc = {
+            "rephrased": classification_request.options.soc.rephrased
+        }
+
+    return ResponseMeta(llm=classification_request.llm, applied_options=applied_options)
+
+
+def _build_classify_response(
+    classification_request: ClassificationRequest,
+    results: list[GenericClassificationResult],
+    meta: ResponseMeta | None,
+) -> Union[GenericClassificationResponse, GenericClassificationResponseWithoutMeta]:
+    """Return classify response with or without meta depending on options."""
+    if meta is None:
+        return GenericClassificationResponseWithoutMeta(
             requested_type=classification_request.type,
             results=results,
-            meta=meta,
         )
+    return GenericClassificationResponse(
+        requested_type=classification_request.type,
+        results=results,
+        meta=meta,
+    )
+
+
+@router.post(
+    "/classify",
+    response_model=Union[
+        GenericClassificationResponse, GenericClassificationResponseWithoutMeta
+    ],
+)
+async def classify_text(
+    request: Request,
+    classification_request: ClassificationRequest,
+    clients: ClassifyClients = classify_clients_dependency,
+) -> Union[GenericClassificationResponse, GenericClassificationResponseWithoutMeta]:
+    """Classify the provided text using the generic response format.
+
+    Args:
+        request: The FastAPI request object.
+        classification_request: The classification request body.
+        clients: Vector store and rephrase clients for SIC and SOC legs.
+
+    Returns:
+        Classification results in generic format, with meta when options were sent.
+
+    Raises:
+        HTTPException: If the input is invalid or classification fails.
+    """
+    start_time = time.perf_counter()
+    body_id = _classify_body_id(classification_request)
+    logger.info(
+        "Request received for classify",
+        type=classification_request.type,
+        body_id=body_id,
+        job_title=truncate_identifier(classification_request.job_title),
+        job_description=truncate_identifier(classification_request.job_description),
+        org_description=truncate_identifier(classification_request.org_description),
+    )
+    _validate_classify_request(classification_request, body_id)
+
+    try:
+        results = await _collect_classify_results(
+            request, classification_request, clients, body_id
+        )
+        meta = _build_classify_meta(classification_request)
+        response_obj = _build_classify_response(classification_request, results, meta)
         duration_ms = int((time.perf_counter() - start_time) * 1000)
         logger.info(
             "Response sent for classify",
@@ -492,7 +530,9 @@ def _apply_rephrasing(
     """
     type_label = classification_type.upper()
     if classification_request.options:
-        type_options = getattr(classification_request.options, classification_type, None)
+        type_options = getattr(
+            classification_request.options, classification_type, None
+        )
         rephrasing_enabled = (
             type_options.rephrased if type_options is not None else True
         )

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -33,12 +33,6 @@ logger = get_logger(__name__)
 
 MAX_LEN = 12
 
-# Temporary: server-side clear-winner thresholds only while SOC classify is single-step.
-# SIC uses a dedicated unambiguous vs follow-up path instead. Remove or replace these
-# when SOC is brought in line with that SIC-style multi-step flow.
-SOC_CLEAR_WINNER_MIN_LIKELIHOOD = 0.85
-SOC_CLEAR_WINNER_MIN_GAP = 0.2
-
 
 def get_sic_vector_store_client() -> SICVectorStoreClient:
     """Get a SIC vector store client instance.
@@ -576,50 +570,29 @@ def _apply_soc_rephrasing(
         return result
 
 
-def _select_soc_clear_winner(
-    candidates: list[GenericCandidate],
-) -> Optional[GenericCandidate]:
-    """Return top candidate when SOC evidence is clearly unambiguous.
-
-    SIC-equivalent decision behaviour for SOC: commit to a final code in
-    obvious cases and reserve follow-up questions for genuinely ambiguous
-    candidate sets.
-    """
-    if not candidates:
-        return None
-
-    ranked = sorted(
-        candidates,
-        key=lambda candidate: float(candidate.likelihood),
-        reverse=True,
-    )
-    top = ranked[0]
-    if top.likelihood < SOC_CLEAR_WINNER_MIN_LIKELIHOOD:
-        return None
-
-    if len(ranked) == 1:
-        return top
-
-    gap = top.likelihood - ranked[1].likelihood
-    if gap < SOC_CLEAR_WINNER_MIN_GAP:
-        return None
-    return top
-
-
 async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
     request: Request,
     classification_request: ClassificationRequest,
     vector_store: SOCVectorStoreClient,
     body_id: str,
 ) -> GenericClassificationResult:
-    """Classify using SOC classification (single-step RAG with vector store).
+    """Classify using SOC classification with two-step process (mirrors ``_classify_sic``).
 
-    Mirrors the pre-two-step SIC flow: vector store search then one LLM call
-    with the short list. No second prompt for open question formulation.
+    Args:
+        request (Request): The FastAPI request object.
+        classification_request (ClassificationRequest): The classification request.
+        vector_store (SOCVectorStoreClient): SOC vector store client.
+        body_id (str): Pseudo correlation ID built from truncated request fields.
+
+    Returns:
+        GenericClassificationResult: SOC classification result.
+
+    Raises:
+        HTTPException: If the two-step process fails with 422 status, or SOC LLM is
+            unavailable (503).
     """
     try:
-        # Mirror SIC: LLM from app state. SIC uses request.app.state.gemini_llm (required);
-        # SOC is optional, so 503 if not configured.
+        # SOC LLM from app state (optional; 503 if soc-classification-utils not loaded).
         llm = getattr(request.app.state, "soc_llm", None)
         if llm is None:
             logger.error(
@@ -640,7 +613,7 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
                 },
             )
 
-        # Get vector store search results (same order as SIC: search then LLM)
+        # Get vector store search results
         search_results = await vector_store.search(
             industry_descr=classification_request.org_description,
             job_title=classification_request.job_title,
@@ -648,7 +621,7 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
             correlation_id=body_id,
         )
 
-        # Build short_list for LLM (same shape as SIC: code, title, distance)
+        # Prepare shortlist for LLM (list of dicts with code/title/distance)
         short_list = [
             {
                 "code": result["code"],
@@ -670,73 +643,139 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
                 reasoning="No SOC candidates returned from vector store search.",
             )
 
-        # Single-step LLM call (async SOC LLM, mirrors SIC sa_rag_sic_code flow)
+        # Step 1: Call unambiguous SOC code classification
         logger.info(
-            f"LLM request sent for SOC classification (single-step RAG) - "
+            f"LLM request sent for unambiguous SOC classification - "
             f"job_title: '{truncate_identifier(classification_request.job_title)}', "
             f"job_description: '{truncate_identifier(classification_request.job_description)}', "
             f"org_description: '{truncate_identifier(classification_request.org_description)}'",
             body_id=body_id,
         )
-        llm_start = time.perf_counter()
-        llm_response, _, _ = await llm.sa_rag_soc_code(
-            industry_descr=classification_request.org_description or "",
-            job_title=classification_request.job_title,
-            job_description=classification_request.job_description,
-            expand_search_terms=True,
-            code_digits=4,
-            candidates_limit=5,
-            short_list=short_list,
-        )
-        llm_duration_ms = int((time.perf_counter() - llm_start) * 1000)
-        logger.info(
-            "LLM response received for SOC single-step prompt",
-            has_code=str(bool(getattr(llm_response, "soc_code", None))),
-            duration_ms=str(llm_duration_ms),
-            body_id=body_id,
-        )
-
-        # Map to generic result (SurveyAssistSocResponse)
-        soc_candidates = getattr(llm_response, "soc_candidates", []) or []
-        candidates = [
-            GenericCandidate(
-                code=c.soc_code,
-                descriptive=c.soc_descriptive,
-                likelihood=c.likelihood,
+        try:
+            llm_start = time.perf_counter()
+            unambiguous_response, _ = await llm.unambiguous_soc_code(
+                industry_descr=classification_request.org_description or "",
+                semantic_search_results=short_list,
+                job_title=classification_request.job_title,
+                job_description=classification_request.job_description,
+                correlation_id=body_id,
             )
-            for c in soc_candidates
-        ]
+            llm_duration_ms = int((time.perf_counter() - llm_start) * 1000)
+            logger.info(
+                "LLM response received for unambiguous soc prompt",
+                codable=str(bool(getattr(unambiguous_response, "codable", False))),
+                selected_code=(
+                    str(getattr(unambiguous_response, "class_code", ""))
+                    if bool(getattr(unambiguous_response, "codable", False))
+                    else ""
+                ),
+                alt_candidates_count=str(
+                    len(getattr(unambiguous_response, "alt_candidates", []) or [])
+                ),
+                duration_ms=str(llm_duration_ms),
+                body_id=body_id,
+            )
+        except Exception as e:
+            logger.error(
+                "Error in unambiguous SOC classification", error=str(e), body_id=body_id
+            )
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "error": {
+                        "type": "classification_error",
+                        "message": "The LLM could not generate a valid classification",
+                        "details": f"Unambiguous SOC classification failed: {e!s}",
+                    }
+                },
+            ) from e
 
-        code = getattr(llm_response, "soc_code", None)
-        description = getattr(llm_response, "soc_descriptive", None)
-        classified = bool(code and str(code).strip())
-        followup = getattr(llm_response, "followup", None)
-
-        if not classified:
-            clear_winner = _select_soc_clear_winner(candidates)
-            if clear_winner is not None:
-                code = clear_winner.code
-                description = clear_winner.descriptive
-                classified = True
-                followup = None
-                logger.info(
-                    "SOC classification promoted to final code from clear winner",
-                    body_id=body_id,
-                    promoted_code=str(code),
-                    top_likelihood=str(clear_winner.likelihood),
+        # Check if unambiguous classification found a match
+        if unambiguous_response.codable and unambiguous_response.class_code:
+            candidates = [
+                GenericCandidate(
+                    code=c.class_code,
+                    descriptive=c.class_descriptive,
+                    likelihood=c.likelihood,
                 )
+                for c in unambiguous_response.alt_candidates
+            ]
+            result = GenericClassificationResult(
+                type="soc",
+                classified=True,
+                followup=None,
+                code=unambiguous_response.class_code,
+                description=unambiguous_response.class_descriptive,
+                candidates=candidates,
+                reasoning=unambiguous_response.reasoning,
+            )
+        else:
+            # No unambiguous match found - call formulate open question
+            job_title_trunc = truncate_identifier(classification_request.job_title)
+            job_desc_trunc = truncate_identifier(classification_request.job_description)
+            org_desc_trunc = truncate_identifier(classification_request.org_description)
+            logger.info(
+                f"LLM request sent to formulate open question (SOC) - "
+                f"job_title: '{job_title_trunc}', "
+                f"job_description: '{job_desc_trunc}', "
+                f"org_description: '{org_desc_trunc}'",
+                body_id=body_id,
+            )
+            try:
+                llm_start2 = time.perf_counter()
+                open_question_response, _ = await llm.formulate_open_question(
+                    industry_descr=classification_request.org_description or "",
+                    job_title=classification_request.job_title,
+                    job_description=classification_request.job_description,
+                    llm_output=unambiguous_response.alt_candidates,
+                    correlation_id=body_id,
+                )
+                llm_duration2_ms = int((time.perf_counter() - llm_start2) * 1000)
+                logger.info(
+                    "LLM response received for open question prompt (SOC)",
+                    has_followup=str(
+                        bool(getattr(open_question_response, "followup", None))
+                    ),
+                    duration_ms=str(llm_duration2_ms),
+                    body_id=body_id,
+                )
+            except Exception as e:
+                logger.error(
+                    "Error in formulate open question (SOC)",
+                    error=str(e),
+                    body_id=body_id,
+                )
+                raise HTTPException(
+                    status_code=422,
+                    detail={
+                        "error": {
+                            "type": "classification_error",
+                            "message": "The LLM could not generate a valid classification",
+                            "details": f"Open question formulation failed: {e!s}",
+                        }
+                    },
+                ) from e
 
-        result = GenericClassificationResult(
-            type="soc",
-            classified=classified,
-            followup=followup if not classified else None,
-            code=code if classified else None,
-            description=description if classified else None,
-            candidates=candidates,
-            reasoning=getattr(llm_response, "reasoning", "") or "",
-        )
+            # Map candidates from unambiguous response
+            candidates = [
+                GenericCandidate(
+                    code=c.class_code,
+                    descriptive=c.class_descriptive,
+                    likelihood=c.likelihood,
+                )
+                for c in unambiguous_response.alt_candidates
+            ]
+            result = GenericClassificationResult(
+                type="soc",
+                classified=False,
+                followup=open_question_response.followup,
+                code=None,
+                description=None,
+                candidates=candidates,
+                reasoning=unambiguous_response.reasoning,
+            )
 
-        # Mirror SIC behaviour - rephrasing defaults to enabled unless explicitly false.
+        # Apply rephrasing if enabled (behaviour unchanged from pre-SA-693)
         soc_rephrase_client = getattr(request.app.state, "soc_rephrase_client", None)
         if soc_rephrase_client and (result.code or result.candidates):
             result = _apply_soc_rephrasing(
@@ -761,11 +800,11 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
         return result
 
     except HTTPException:
+        # Re-raise HTTP exceptions as they are already properly formatted
         raise
     except Exception as e:
-        # Mirror SIC: same 422 detail shape and logging (error, body_id)
         logger.error(
-            "Error in SOC classification (single-step)",
+            "Unexpected error in SOC classification",
             error=str(e),
             body_id=body_id,
         )
@@ -774,8 +813,8 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
             detail={
                 "error": {
                     "type": "classification_error",
-                    "message": "The LLM could not generate a valid SOC classification",
-                    "details": f"SOC classification failed: {e!s}",
+                    "message": "The LLM could not generate a valid classification",
+                    "details": f"Response was empty or invalid JSON: {e!s}",
                 }
             },
         ) from e

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -646,7 +646,6 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
                 semantic_search_results=short_list,
                 job_title=classification_request.job_title,
                 job_description=classification_request.job_description,
-                correlation_id=body_id,
             )
             llm_duration_ms = int((time.perf_counter() - llm_start) * 1000)
             logger.info(
@@ -716,7 +715,6 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
                     job_title=classification_request.job_title,
                     job_description=classification_request.job_description,
                     llm_output=unambiguous_response.alt_candidates,
-                    correlation_id=body_id,
                 )
                 llm_duration2_ms = int((time.perf_counter() - llm_start2) * 1000)
                 logger.info(

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -579,9 +579,6 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
         HTTPException: If the two-step process fails with 422 status.
     """
     try:
-        # Get LLM instance (mirrors SIC: request.app.state.gemini_llm)
-        llm = request.app.state.soc_llm
-
         # Get vector store search results
         search_results = await vector_store.search(
             industry_descr=classification_request.org_description,
@@ -590,15 +587,18 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
             correlation_id=body_id,
         )
 
-        # Prepare shortlist for LLM (list of dicts with code/title/distance)
+        # Prepare shortlist for LLM (list of dicts with code/title/likelihood)
         short_list = [
             {
                 "code": result["code"],
                 "title": result["title"],
-                "distance": result.get("distance", 0.0),
+                "distance": result["distance"],
             }
             for result in search_results
         ]
+
+        # Get LLM instance
+        llm = request.app.state.soc_llm
 
         # Step 1: Call unambiguous SOC code classification
         logger.info(

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -673,7 +673,7 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
             job_desc_trunc = truncate_identifier(classification_request.job_description)
             org_desc_trunc = truncate_identifier(classification_request.org_description)
             logger.info(
-                f"LLM request sent to formulate open question (SOC) - "
+                f"LLM request sent to formulate open question - "
                 f"job_title: '{job_title_trunc}', "
                 f"job_description: '{job_desc_trunc}', "
                 f"org_description: '{org_desc_trunc}'",
@@ -689,7 +689,7 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
                 )
                 llm_duration2_ms = int((time.perf_counter() - llm_start2) * 1000)
                 logger.info(
-                    "LLM response received for open question prompt (SOC)",
+                    "LLM response received for open question prompt",
                     has_followup=str(
                         bool(getattr(open_question_response, "followup", None))
                     ),
@@ -698,7 +698,7 @@ async def _classify_soc(  # pylint: disable=unused-argument,too-many-locals
                 )
             except Exception as e:
                 logger.error(
-                    "Error in formulate open question (SOC)",
+                    "Error in formulate open question",
                     error=str(e),
                     body_id=body_id,
                 )

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -258,6 +258,8 @@ async def classify_text(
         )
         return response_obj
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("Error in classify endpoint", error=str(e), body_id=body_id)
         raise HTTPException(

--- a/api/routes/v1/config.py
+++ b/api/routes/v1/config.py
@@ -136,6 +136,10 @@ def _get_sic_prompts(request: Request) -> dict[str, str]:
                     getattr(llm, "sic_prompt_unambiguous", None),
                     "[Core prompt] + [SIC unambiguous template]",
                 ),
+                "open_followup": _prompt_template_text(
+                    getattr(llm, "sic_prompt_openfollowup", None),
+                    "[Core prompt] + [SIC open follow-up template]",
+                ),
             }
     except (AttributeError, TypeError, RuntimeError) as e:
         logger.warning(f"Could not retrieve SIC prompts from LLM: {e}")
@@ -144,6 +148,7 @@ def _get_sic_prompts(request: Request) -> dict[str, str]:
         "sa_rag": "[Core prompt] + [Survey Assist SIC RAG template]",
         "reranker": "[Core prompt] + [SIC reranker template]",
         "unambiguous": "[Core prompt] + [SIC unambiguous template]",
+        "open_followup": "[Core prompt] + [SIC open follow-up template]",
     }
 
 
@@ -233,6 +238,10 @@ async def get_config(
                         PromptModel(
                             name="SIC_PROMPT_UNAMBIGUOUS",
                             text=sic_prompts["unambiguous"],
+                        ),
+                        PromptModel(
+                            name="SIC_PROMPT_OPENFOLLOWUP",
+                            text=sic_prompts["open_followup"],
                         ),
                     ],
                 ),

--- a/api/routes/v1/config.py
+++ b/api/routes/v1/config.py
@@ -249,6 +249,10 @@ async def get_config(
                     type="soc",
                     prompts=[
                         PromptModel(
+                            name="SA_SOC_PROMPT_RAG",
+                            text=soc_prompts["sa_rag"],
+                        ),
+                        PromptModel(
                             name="SOC_PROMPT_UNAMBIGUOUS",
                             text=soc_prompts["unambiguous"],
                         ),

--- a/api/routes/v1/config.py
+++ b/api/routes/v1/config.py
@@ -111,53 +111,68 @@ def _get_actual_prompt(request: Request) -> str:
         return "Could not retrieve actual prompt"
 
 
-def _get_prompts_from_llm(request: Request) -> dict:
-    """Get actual prompts from the LLM instance.
+def _prompt_template_text(prompt: Any, fallback: str) -> str:
+    """Return prompt template text or a fallback label."""
+    if prompt is not None:
+        return str(prompt.template)
+    return fallback
 
-    Args:
-        request: The FastAPI request object.
 
-    Returns:
-        dict: Dictionary containing the actual prompts or fallback text.
-    """
+def _get_sic_prompts(request: Request) -> dict[str, str]:
+    """Get SIC prompt templates from the SIC LLM on app state."""
     try:
         if hasattr(request.app.state, "gemini_llm"):
             llm = request.app.state.gemini_llm
-            # Get the actual prompt templates from the LLM instance
-            sa_sic_prompt = getattr(llm, "sa_sic_prompt_rag", None)
-            sic_reranker_prompt = getattr(llm, "sic_prompt_reranker", None)
-            sic_unambiguous_prompt = getattr(llm, "sic_prompt_unambiguous", None)
-
-            # Extract the template text if available
-            sa_sic_text = (
-                str(sa_sic_prompt.template)
-                if sa_sic_prompt
-                else "[Core prompt] + [Survey Assist SIC RAG template]"
-            )
-            reranker_text = (
-                str(sic_reranker_prompt.template)
-                if sic_reranker_prompt
-                else "[Core prompt] + [SIC reranker template]"
-            )
-            unambiguous_text = (
-                str(sic_unambiguous_prompt.template)
-                if sic_unambiguous_prompt
-                else "[Core prompt] + [SIC unambiguous template]"
-            )
-
             return {
-                "sa_sic_text": sa_sic_text,
-                "reranker_text": reranker_text,
-                "unambiguous_text": unambiguous_text,
+                "sa_rag": _prompt_template_text(
+                    getattr(llm, "sa_sic_prompt_rag", None),
+                    "[Core prompt] + [Survey Assist SIC RAG template]",
+                ),
+                "reranker": _prompt_template_text(
+                    getattr(llm, "sic_prompt_reranker", None),
+                    "[Core prompt] + [SIC reranker template]",
+                ),
+                "unambiguous": _prompt_template_text(
+                    getattr(llm, "sic_prompt_unambiguous", None),
+                    "[Core prompt] + [SIC unambiguous template]",
+                ),
             }
     except (AttributeError, TypeError, RuntimeError) as e:
-        logger.warning(f"Could not retrieve prompts from LLM: {e}")
+        logger.warning(f"Could not retrieve SIC prompts from LLM: {e}")
 
-    # Fallback to placeholder text
     return {
-        "sa_sic_text": "[Core prompt] + [Survey Assist SIC RAG template]",
-        "reranker_text": "[Core prompt] + [SIC reranker template]",
-        "unambiguous_text": "[Core prompt] + [SIC unambiguous template]",
+        "sa_rag": "[Core prompt] + [Survey Assist SIC RAG template]",
+        "reranker": "[Core prompt] + [SIC reranker template]",
+        "unambiguous": "[Core prompt] + [SIC unambiguous template]",
+    }
+
+
+def _get_soc_prompts(request: Request) -> dict[str, str]:
+    """Get SOC prompt templates from the SOC LLM on app state."""
+    try:
+        if hasattr(request.app.state, "soc_llm"):
+            llm = request.app.state.soc_llm
+            return {
+                "sa_rag": _prompt_template_text(
+                    getattr(llm, "sa_soc_prompt_rag", None),
+                    "[Core prompt] + [Survey Assist SOC RAG template]",
+                ),
+                "unambiguous": _prompt_template_text(
+                    getattr(llm, "soc_prompt_unambiguous", None),
+                    "[Core prompt] + [SOC unambiguous template]",
+                ),
+                "open_followup": _prompt_template_text(
+                    getattr(llm, "soc_prompt_openfollowup", None),
+                    "[Core prompt] + [SOC open follow-up template]",
+                ),
+            }
+    except (AttributeError, TypeError, RuntimeError) as e:
+        logger.warning(f"Could not retrieve SOC prompts from LLM: {e}")
+
+    return {
+        "sa_rag": "[Core prompt] + [Survey Assist SOC RAG template]",
+        "unambiguous": "[Core prompt] + [SOC unambiguous template]",
+        "open_followup": "[Core prompt] + [SOC open follow-up template]",
     }
 
 
@@ -180,10 +195,9 @@ async def get_config(
     # Get actual prompt used by making a test classification call
     actual_prompt = _get_actual_prompt(request)
 
-    # Get actual prompts from LLM instance
-    prompts = _get_prompts_from_llm(request)
+    sic_prompts = _get_sic_prompts(request)
+    soc_prompts = _get_soc_prompts(request)
 
-    # Return config with actual model names and prompts
     return ConfigResponse(
         llm_model=actual_llm_model,
         data_store="Firestore",
@@ -194,10 +208,18 @@ async def get_config(
                     type="sic",
                     prompts=[
                         PromptModel(
-                            name="SA_SIC_PROMPT_RAG", text=prompts["sa_sic_text"]
+                            name="SA_SIC_PROMPT_RAG", text=sic_prompts["sa_rag"]
                         ),
                     ],
-                )
+                ),
+                ClassificationModel(
+                    type="soc",
+                    prompts=[
+                        PromptModel(
+                            name="SA_SOC_PROMPT_RAG", text=soc_prompts["sa_rag"]
+                        ),
+                    ],
+                ),
             ]
         },
         v3={
@@ -206,14 +228,27 @@ async def get_config(
                     type="sic",
                     prompts=[
                         PromptModel(
-                            name="SIC_PROMPT_RERANKER", text=prompts["reranker_text"]
+                            name="SIC_PROMPT_RERANKER", text=sic_prompts["reranker"]
                         ),
                         PromptModel(
                             name="SIC_PROMPT_UNAMBIGUOUS",
-                            text=prompts["unambiguous_text"],
+                            text=sic_prompts["unambiguous"],
                         ),
                     ],
-                )
+                ),
+                ClassificationModel(
+                    type="soc",
+                    prompts=[
+                        PromptModel(
+                            name="SOC_PROMPT_UNAMBIGUOUS",
+                            text=soc_prompts["unambiguous"],
+                        ),
+                        PromptModel(
+                            name="SOC_PROMPT_OPENFOLLOWUP",
+                            text=soc_prompts["open_followup"],
+                        ),
+                    ],
+                ),
             ]
         },
         embedding_model=embedding_model,

--- a/docs/generic_classification.md
+++ b/docs/generic_classification.md
@@ -21,7 +21,7 @@ The classification process works as follows:
 ### Current Implementation Status
 
 - **SIC Classification**: Fully implemented with vector store search, LLM classification, and rephrasing support.
-- **SOC Classification**: Implemented as a single-step RAG flow using the SOC vector store and a SOC LLM (when configured), with optional SOC rephrasing backed by `soc-classification-library`.
+- **SOC Classification**: Two-step flow (mirrors SIC): vector store search, then `unambiguous_soc_code`, then `formulate_open_question` when not codable. Optional SOC rephrasing backed by `soc-classification-library`.
 
 ## Endpoints
 

--- a/docs/generic_classification.md
+++ b/docs/generic_classification.md
@@ -171,7 +171,7 @@ The endpoint returns a generic classification response that can contain one or m
     - `soc` (object, optional): Applied SOC options
 
 **Important Notes:**
-- **SOC Classification**: Uses the SOC vector store and SOC LLM to produce real SOC codes and candidates when those services are configured. If the SOC LLM is not available, requests with `type="soc"` or `type="sic_soc"` will return a 503 `"SOC classification is not available"` error.
+- **SOC Classification**: Uses the SOC vector store and the SOC LLM (two-step: `unambiguous_soc_code`, then `formulate_open_question` when not codable). The SOC LLM is initialised at API startup alongside the SIC LLM. Unreachable vector stores or LLM failures surface as request errors (for example 422 for LLM classification failures), not a separate “SOC unavailable” 503.
 - **Meta Field**: The `meta` field is only included in the response when `options` are provided in the request. This allows clients to see which options were actually applied.
 
 ## Rephrasing Feature
@@ -470,7 +470,7 @@ curl -X POST "http://localhost:8080/v1/survey-assist/classify" \
           "likelihood": 1.0
         }
       ],
-      "reasoning": "Placeholder SOC classification reasoning"
+      "reasoning": "The job title 'Farmer' and description of growing cereals on an agricultural farm align with SOC unit group 9111 (Farm workers), which covers general farm work including crop growing. The shortlist and respondent data support a single four-digit code with high confidence."
     }
   ],
   "meta": {
@@ -490,8 +490,8 @@ curl -X POST "http://localhost:8080/v1/survey-assist/classify" \
 **Note:** 
 
 - SIC results show rephrased descriptions in the `candidates` array when rephrasing is enabled.
-- SOC classification uses the SOC vector store and SOC LLM to return real SOC codes and candidates when configured; where SOC rephrased descriptions exist they can be applied to the SOC code and candidates.
-- **SOC vector store and SOC LLM must be running** for `type="sic_soc"` requests involving SOC to succeed. If the SOC LLM is not available, the request will return a 503 error for the SOC part of the classification.
+- SOC classification uses the same two-step flow as SIC (`unambiguous_soc_code`, then `formulate_open_question` when not codable). Where SOC rephrased descriptions exist they can be applied to candidates when `options.soc.rephrased` is true.
+- For `type="sic_soc"`, both the SIC and SOC vector stores must be reachable; each leg runs the two-step classify flow independently.
 
 ### Data Coverage Note
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -76,6 +76,10 @@ The API is built using:
             { 
               "name": "SIC_PROMPT_UNAMBIGUOUS", 
               "text": "You are a conscientious classification assistant... [full prompt text]" 
+            },
+            { 
+              "name": "SIC_PROMPT_OPENFOLLOWUP", 
+              "text": "You are a conscientious classification assistant... [full prompt text]" 
             }
           ]
         },
@@ -99,7 +103,7 @@ The API is built using:
   
   **Note**: The `text` field in each prompt is the full template from the utils package (it starts with `You are a conscientious classification assistant...`). The ellipsis in the example above is only for readability in this doc.
 
-  - **v3 `soc`** lists `SOC_PROMPT_UNAMBIGUOUS` and `SOC_PROMPT_OPENFOLLOWUP` (the two-step classify flow). There is no SOC reranker entry (SIC still includes `SIC_PROMPT_RERANKER`).
+  - **v3 two-step classify prompts**: `sic` lists `SIC_PROMPT_UNAMBIGUOUS` and `SIC_PROMPT_OPENFOLLOWUP` (plus `SIC_PROMPT_RERANKER` for reranking); `soc` lists `SOC_PROMPT_UNAMBIGUOUS` and `SOC_PROMPT_OPENFOLLOWUP`. There is no SOC reranker entry.
   - **`embedding_model`** comes from the **SIC** vector store (`SIC_VECTOR_STORE`, default `http://localhost:8088`). It is `unknown` when that service is not reachable. A running **SOC** vector store on port 8089 does not populate this field.
   - **`firestore_database_id`** is `not-configured` when `FIRESTORE_DB_ID` is unset (typical local run).
   - **`actual_prompt`** is a fixed sample string, not the live classify prompt.
@@ -117,7 +121,7 @@ The API is built using:
   "
   ```
 
-  Expected prompt names when the current API code is loaded: `v1v2` — `sic` → `SA_SIC_PROMPT_RAG`, `soc` → `SA_SOC_PROMPT_RAG`; `v3` — `sic` → `SIC_PROMPT_RERANKER`, `SIC_PROMPT_UNAMBIGUOUS`, `soc` → `SOC_PROMPT_UNAMBIGUOUS`, `SOC_PROMPT_OPENFOLLOWUP`.
+  Expected prompt names when the current API code is loaded: `v1v2` — `sic` → `SA_SIC_PROMPT_RAG`, `soc` → `SA_SOC_PROMPT_RAG`; `v3` — `sic` → `SIC_PROMPT_RERANKER`, `SIC_PROMPT_UNAMBIGUOUS`, `SIC_PROMPT_OPENFOLLOWUP`, `soc` → `SOC_PROMPT_UNAMBIGUOUS`, `SOC_PROMPT_OPENFOLLOWUP`.
 
 ### Classification Endpoint
 - **Path**: `/v1/survey-assist/classify`

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -16,7 +16,7 @@ The API is built using:
 
 **Important Notes**:
 
-- **SOC Classification**: Uses a single-step RAG flow with the SOC vector store and a SOC LLM (when configured). If the SOC LLM is not available, requests with `type="soc"` or `type="sic_soc"` return a 503 `"SOC classification is not available"` error. SOC **rephrasing** is applied only for codes that exist in the SOC rephrase dataset from `soc-classification-library`.
+- **SOC Classification**: Uses the same two-step flow as SIC: SOC vector-store search, then `unambiguous_soc_code`, then `formulate_open_question` when the first step is not codable. Both steps use the SOC LLM initialised at API startup (`gemini-2.5-flash`). SOC **rephrasing** is applied only for codes that exist in the SOC rephrase dataset from `soc-classification-library`.
 - **Firestore**: Result and feedback endpoints require `FIRESTORE_DB_ID` to be set. If not configured, these endpoints will return 503 errors.
 
 ## API Endpoints
@@ -114,15 +114,15 @@ The API is built using:
       - `sic` (object, optional): Applied SIC options
       - `soc` (object, optional): Applied SOC options
     
-    **Note**: SOC classification depends on the SOC vector store and SOC LLM being configured. If they are not available, SOC requests will return a 503 error indicating that SOC classification is not available.
+    **Note**: SIC and SOC classification require the corresponding vector store service to be reachable. Classification failures from the LLM (for example invalid or unparseable responses) return HTTP 422 with a classification error payload.
 
-The classification process works as follows:
+The classification process works as follows (the same steps apply to SIC and SOC; only the vector store, LLM client, and code scheme differ):
 
-1. The input text is used to search the vector store for a list of candidate SIC codes.
-2. The LLM first attempts to find an **unambiguous** classification from the candidates.
-3. If a definitive SIC code is found, the API returns a response with `classified: true` and the found code. The `followup` field will be `null`.
-4. If the result is ambiguous and a definitive code cannot be determined, the LLM then formulates a **follow-up question** to gather more information from the user.
-5. In this case, the API returns a response with `classified: false`, no code/description, and the `followup` question populated.
+1. The input text is used to search the vector store for a shortlist of candidate codes.
+2. The LLM first attempts an **unambiguous** classification from that shortlist (`unambiguous_sic_code` or `unambiguous_soc_code`).
+3. If a definitive code is found (`codable: true`), the API returns `classified: true`, the code and description, candidates from the first step, and `followup: null`.
+4. If the result is not codable, the LLM formulates a **follow-up question** (`formulate_open_question`) using the alternative candidates from step 2.
+5. In that case, the API returns `classified: false`, `code` and `description` null, candidates and reasoning from step 2, and a non-empty `followup`.
 
 
 ### Result Endpoints

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -38,9 +38,9 @@ The API is built using:
   ```json
   {
     "llm_model": "gemini-2.5-flash",
-    "embedding_model": "all-MiniLM-L6-v2",
+    "embedding_model": "unknown",
     "data_store": "Firestore",
-    "firestore_database_id": "your-database-id",
+    "firestore_database_id": "not-configured",
     "actual_prompt": "Sample SIC classification prompt for testing purposes",
     "v1v2": {
       "classification": [
@@ -50,6 +50,15 @@ The API is built using:
             { 
               "name": "SA_SIC_PROMPT_RAG", 
               "text": "You are a conscientious classification assistant... [full prompt text]" 
+            }
+          ]
+        },
+        {
+          "type": "soc",
+          "prompts": [
+            {
+              "name": "SA_SOC_PROMPT_RAG",
+              "text": "You are a conscientious classification assistant... [full prompt text]"
             }
           ]
         }
@@ -69,13 +78,46 @@ The API is built using:
               "text": "You are a conscientious classification assistant... [full prompt text]" 
             }
           ]
+        },
+        {
+          "type": "soc",
+          "prompts": [
+            {
+              "name": "SOC_PROMPT_UNAMBIGUOUS",
+              "text": "You are a conscientious classification assistant... [full prompt text]"
+            },
+            {
+              "name": "SOC_PROMPT_OPENFOLLOWUP",
+              "text": "You are a conscientious classification assistant... [full prompt text]"
+            }
+          ]
         }
       ]
     }
   }
   ```
   
-  **Note**: The `text` field in prompts contains the full prompt template text, not placeholder text. The `embedding_model` is retrieved from the vector store service. The `actual_prompt` field contains a sample/fallback text.
+  **Note**: The `text` field in each prompt is the full template from the utils package (it starts with `You are a conscientious classification assistant...`). The ellipsis in the example above is only for readability in this doc.
+
+  - **v3 `soc`** lists `SOC_PROMPT_UNAMBIGUOUS` and `SOC_PROMPT_OPENFOLLOWUP` (the two-step classify flow). There is no SOC reranker entry (SIC still includes `SIC_PROMPT_RERANKER`).
+  - **`embedding_model`** comes from the **SIC** vector store (`SIC_VECTOR_STORE`, default `http://localhost:8088`). It is `unknown` when that service is not reachable. A running **SOC** vector store on port 8089 does not populate this field.
+  - **`firestore_database_id`** is `not-configured` when `FIRESTORE_DB_ID` is unset (typical local run).
+  - **`actual_prompt`** is a fixed sample string, not the live classify prompt.
+
+  Verify locally (API on port 8080; restart `make run-api` after pulling config changes so `soc` entries appear):
+
+  ```bash
+  curl -s http://localhost:8080/v1/survey-assist/config | python3 -c "
+  import json, sys
+  d = json.load(sys.stdin)
+  for ver in ('v1v2', 'v3'):
+      for e in d[ver]['classification']:
+          print(ver, e['type'], [p['name'] for p in e['prompts']])
+  print('embedding_model', d.get('embedding_model'))
+  "
+  ```
+
+  Expected prompt names when the current API code is loaded: `v1v2` — `sic` → `SA_SIC_PROMPT_RAG`, `soc` → `SA_SOC_PROMPT_RAG`; `v3` — `sic` → `SIC_PROMPT_RERANKER`, `SIC_PROMPT_UNAMBIGUOUS`, `soc` → `SOC_PROMPT_UNAMBIGUOUS`, `SOC_PROMPT_OPENFOLLOWUP`.
 
 ### Classification Endpoint
 - **Path**: `/v1/survey-assist/classify`

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -87,6 +87,10 @@ The API is built using:
           "type": "soc",
           "prompts": [
             {
+              "name": "SA_SOC_PROMPT_RAG",
+              "text": "You are a conscientious classification assistant... [full prompt text]"
+            },
+            {
               "name": "SOC_PROMPT_UNAMBIGUOUS",
               "text": "You are a conscientious classification assistant... [full prompt text]"
             },
@@ -103,7 +107,7 @@ The API is built using:
   
   **Note**: The `text` field in each prompt is the full template from the utils package (it starts with `You are a conscientious classification assistant...`). The ellipsis in the example above is only for readability in this doc.
 
-  - **v3 two-step classify prompts**: `sic` lists `SIC_PROMPT_UNAMBIGUOUS` and `SIC_PROMPT_OPENFOLLOWUP` (plus `SIC_PROMPT_RERANKER` for reranking); `soc` lists `SOC_PROMPT_UNAMBIGUOUS` and `SOC_PROMPT_OPENFOLLOWUP`. There is no SOC reranker entry.
+  - **v3 prompts**: classify uses `SIC_PROMPT_UNAMBIGUOUS` / `SOC_PROMPT_UNAMBIGUOUS` then `SIC_PROMPT_OPENFOLLOWUP` / `SOC_PROMPT_OPENFOLLOWUP` when not codable. `v3` also lists `SIC_PROMPT_RERANKER` (SIC reranking) and `SA_SOC_PROMPT_RAG` (SOC single-shot RAG, not used on the classify route). SOC has no reranker prompt in utils.
   - **`embedding_model`** comes from the **SIC** vector store (`SIC_VECTOR_STORE`, default `http://localhost:8088`). It is `unknown` when that service is not reachable. A running **SOC** vector store on port 8089 does not populate this field.
   - **`firestore_database_id`** is `not-configured` when `FIRESTORE_DB_ID` is unset (typical local run).
   - **`actual_prompt`** is a fixed sample string, not the live classify prompt.
@@ -121,7 +125,7 @@ The API is built using:
   "
   ```
 
-  Expected prompt names when the current API code is loaded: `v1v2` — `sic` → `SA_SIC_PROMPT_RAG`, `soc` → `SA_SOC_PROMPT_RAG`; `v3` — `sic` → `SIC_PROMPT_RERANKER`, `SIC_PROMPT_UNAMBIGUOUS`, `SIC_PROMPT_OPENFOLLOWUP`, `soc` → `SOC_PROMPT_UNAMBIGUOUS`, `SOC_PROMPT_OPENFOLLOWUP`.
+  Expected prompt names when the current API code is loaded: `v1v2` — `sic` → `SA_SIC_PROMPT_RAG`, `soc` → `SA_SOC_PROMPT_RAG`; `v3` — `sic` → `SIC_PROMPT_RERANKER`, `SIC_PROMPT_UNAMBIGUOUS`, `SIC_PROMPT_OPENFOLLOWUP`, `soc` → `SA_SOC_PROMPT_RAG`, `SOC_PROMPT_UNAMBIGUOUS`, `SOC_PROMPT_OPENFOLLOWUP`.
 
 ### Classification Endpoint
 - **Path**: `/v1/survey-assist/classify`

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,8 @@ The Survey Assist API is a FastAPI service that provides endpoints for both SIC 
 
 ## Key Features
 
-- **SIC classification**: `POST /v1/survey-assist/classify` performs a two-step SIC classification using a vector-store shortlist and a Gemini LLM.
+- **SIC classification**: `POST /v1/survey-assist/classify` performs a two-step SIC classification using a vector-store shortlist and a Gemini LLM (`unambiguous_sic_code`, then `formulate_open_question` when not codable).
+- **SOC classification**: Same endpoint with `type: "soc"` or `"sic_soc"` performs a two-step SOC classification (vector-store shortlist, then `unambiguous_soc_code`, then `formulate_open_question` when not codable).
 - **SIC lookup**: `GET /v1/survey-assist/sic-lookup` looks up SIC codes by description (with optional similarity search).
 - **SOC lookup**: `GET /v1/survey-assist/soc-lookup` looks up SOC codes by description (with optional similarity search).
 - **Vector store status**: `GET /v1/survey-assist/embeddings` checks whether SIC embeddings are ready to query.
@@ -28,6 +29,7 @@ For detailed information on installation, setup, and usage, please refer to the 
 ## Configuration
 
 - **`SIC_VECTOR_STORE`**: Base URL for the SIC vector store (defaults to `http://localhost:8088`).
+- **`SOC_VECTOR_STORE`**: Base URL for the SOC vector store (defaults to `http://localhost:8089`).
 - **`SIC_LOOKUP_DATA_PATH`**: Optional path to a SIC lookup CSV. If unset, packaged example data is used.
 - **`SIC_REPHRASE_DATA_PATH`**: Optional path to a rephrased SIC CSV. If unset, packaged example data is used.
 - **`FIRESTORE_DB_ID`**: Enables Firestore-backed endpoints when set; if unset, result/feedback endpoints will fail because the Firestore client is not initialised.

--- a/poetry.lock
+++ b/poetry.lock
@@ -7712,7 +7712,7 @@ optional = false
 python-versions = "^3.12"
 groups = ["main"]
 files = []
-develop = true
+develop = false
 
 [package.dependencies]
 autocorrect = "^2.6.1"
@@ -7737,8 +7737,10 @@ torch = "2.7.1"
 transformers = ">=4.52.4,<5.0.0"
 
 [package.source]
-type = "directory"
-url = "../soc-classification-utils"
+type = "git"
+url = "https://github.com/ONSdigital/soc-classification-utils.git"
+reference = "v0.1.4"
+resolved_reference = "f017e42c438d507807b21d9fe46f9efdc2f5946a"
 
 [[package]]
 name = "sqlalchemy"
@@ -9116,4 +9118,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "86f660f99af5f1643e0c44bce3346c95f5c48e8555babb25909d2ebd5539d9d5"
+content-hash = "c10fc9cb4529a40bcbfe3f5e9e7300ce7a7483ea76cab589a4c5bef491e1f5b7"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2334,6 +2334,8 @@ files = [
     {file = "greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d"},
     {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5"},
     {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8854167e06950ca75b898b104b63cc646573aa5fef1353d4508ecdd1ee76254f"},
+    {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f47617f698838ba98f4ff4189aef02e7343952df3a615f847bb575c3feb177a7"},
+    {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:af41be48a4f60429d5cad9d22175217805098a9ef7c40bfef44f7669fb9d74d8"},
     {file = "greenlet-3.2.4-cp310-cp310-win_amd64.whl", hash = "sha256:73f49b5368b5359d04e18d15828eecc1806033db5233397748f4ca813ff1056c"},
     {file = "greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2"},
     {file = "greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246"},
@@ -2343,6 +2345,8 @@ files = [
     {file = "greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8"},
     {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52"},
     {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:55e9c5affaa6775e2c6b67659f3a71684de4c549b3dd9afca3bc773533d284fa"},
+    {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c9c6de1940a7d828635fbd254d69db79e54619f165ee7ce32fda763a9cb6a58c"},
+    {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03c5136e7be905045160b1b9fdca93dd6727b180feeafda6818e6496434ed8c5"},
     {file = "greenlet-3.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:9c40adce87eaa9ddb593ccb0fa6a07caf34015a29bf8d344811665b573138db9"},
     {file = "greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd"},
     {file = "greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb"},
@@ -2352,6 +2356,8 @@ files = [
     {file = "greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0"},
     {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0"},
     {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f"},
+    {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee7a6ec486883397d70eec05059353b8e83eca9168b9f3f9a361971e77e0bcd0"},
+    {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:326d234cbf337c9c3def0676412eb7040a35a768efc92504b947b3e9cfc7543d"},
     {file = "greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02"},
     {file = "greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31"},
     {file = "greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945"},
@@ -2361,6 +2367,8 @@ files = [
     {file = "greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671"},
     {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b"},
     {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae"},
+    {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b"},
+    {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929"},
     {file = "greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b"},
     {file = "greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0"},
     {file = "greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f"},
@@ -2368,6 +2376,8 @@ files = [
     {file = "greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1"},
     {file = "greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735"},
     {file = "greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337"},
+    {file = "greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269"},
+    {file = "greenlet-3.2.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:015d48959d4add5d6c9f6c5210ee3803a830dce46356e3bc326d6776bde54681"},
     {file = "greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01"},
     {file = "greenlet-3.2.4-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:b6a7c19cf0d2742d0809a4c05975db036fdff50cd294a93632d6a310bf9ac02c"},
     {file = "greenlet-3.2.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:27890167f55d2387576d1f41d9487ef171849ea0359ce1510ca6e06c8bece11d"},
@@ -2377,6 +2387,8 @@ files = [
     {file = "greenlet-3.2.4-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9913f1a30e4526f432991f89ae263459b1c64d1608c0d22a5c79c287b3c70df"},
     {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b90654e092f928f110e0007f572007c9727b5265f7632c2fa7415b4689351594"},
     {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:81701fd84f26330f0d5f4944d4e92e61afe6319dcd9775e39396e39d7c3e5f98"},
+    {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:28a3c6b7cd72a96f61b0e4b2a36f681025b60ae4779cc73c1535eb5f29560b10"},
+    {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:52206cd642670b0b320a1fd1cbfd95bca0e043179c1d8a045f2c6109dfe973be"},
     {file = "greenlet-3.2.4-cp39-cp39-win32.whl", hash = "sha256:65458b409c1ed459ea899e939f0e1cdb14f58dbc803f2f93c5eab5694d32671b"},
     {file = "greenlet-3.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:d2e685ade4dafd447ede19c31277a224a239a0a1a4eca4e6390efedf20260cfb"},
     {file = "greenlet-3.2.4.tar.gz", hash = "sha256:0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d"},
@@ -4704,8 +4716,11 @@ optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
+    {file = "onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3"},
+    {file = "onnxruntime-1.23.2-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:b28740f4ecef1738ea8f807461dd541b8287d5650b5be33bca7b474e3cbd1f36"},
     {file = "onnxruntime-1.23.2-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f7d1fe034090a1e371b7f3ca9d3ccae2fabae8c1d8844fb7371d1ea38e8e8d2"},
     {file = "onnxruntime-1.23.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4ca88747e708e5c67337b0f65eed4b7d0dd70d22ac332038c9fc4635760018f7"},
+    {file = "onnxruntime-1.23.2-cp310-cp310-win_amd64.whl", hash = "sha256:0be6a37a45e6719db5120e9986fcd30ea205ac8103fd1fb74b6c33348327a0cc"},
     {file = "onnxruntime-1.23.2-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:6f91d2c9b0965e86827a5ba01531d5b669770b01775b23199565d6c1f136616c"},
     {file = "onnxruntime-1.23.2-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:87d8b6eaf0fbeb6835a60a4265fde7a3b60157cf1b2764773ac47237b4d48612"},
     {file = "onnxruntime-1.23.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbfd2fca76c855317568c1b36a885ddea2272c13cb0e395002c402f2360429a6"},
@@ -7606,12 +7621,12 @@ pydantic = "^2.11.7"
 [package.source]
 type = "git"
 url = "https://github.com/ONSdigital/sic-classification-library.git"
-reference = "v0.1.3"
-resolved_reference = "3487e260c58072337818b314d74dce8ba24750b3"
+reference = "v0.1.4"
+resolved_reference = "2f2592dfc501ea48ee1fb0a9a452bbea2e3642c1"
 
 [[package]]
 name = "sic-classification-utils"
-version = "0.1.11"
+version = "0.1.12"
 description = "Utility functions used for SIC classification"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -7633,14 +7648,14 @@ pandas = "^2.3.0"
 pydantic = "^2.11.1"
 scikit-learn = "^1.3.0"
 scipy = "^1.15.0"
-sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.3"}
+sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.4"}
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.8"}
 
 [package.source]
 type = "git"
 url = "https://github.com/ONSdigital/sic-classification-utils.git"
-reference = "v0.1.11"
-resolved_reference = "ec0d88314c0c0a803b598c889a77c5b88f9fcd93"
+reference = "v0.1.12"
+resolved_reference = "cbe4833f6c903217c628e49b49270413a4865ead"
 
 [[package]]
 name = "six"
@@ -7697,7 +7712,7 @@ optional = false
 python-versions = "^3.12"
 groups = ["main"]
 files = []
-develop = false
+develop = true
 
 [package.dependencies]
 autocorrect = "^2.6.1"
@@ -7722,10 +7737,8 @@ torch = "2.7.1"
 transformers = ">=4.52.4,<5.0.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/ONSdigital/soc-classification-utils.git"
-reference = "v0.1.3"
-resolved_reference = "d9286495c35184b710499d68ff74b1691b8dbdea"
+type = "directory"
+url = "../soc-classification-utils"
 
 [[package]]
 name = "sqlalchemy"
@@ -9103,4 +9116,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "b162a2dda48353b4a77f0288db91a0517202ad55892e9eec774a45aa7df1e2ed"
+content-hash = "79229c84d09de0d7361cbdca6f41fbe1daaa7f8ee9e5494f58723db05785b2a6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ pandas = "^2.1.4"
 google-cloud-logging = "^3.9.0"
 google-auth = "^2.28.0"
 fastapi_swagger2 = "^0.2.4"
-sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.3"}
-sic-classification-utils = {git = "https://github.com/ONSdigital/sic-classification-utils.git", tag = "v0.1.11"}
+sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.4"}
+sic-classification-utils = {git = "https://github.com/ONSdigital/sic-classification-utils.git", tag = "v0.1.12"}
 soc-classification-library = {git = "https://github.com/ONSdigital/soc-classification-library.git", tag = "v0.1.5"}
-soc-classification-utils = {git = "https://github.com/ONSdigital/soc-classification-utils.git", tag = "v0.1.3"}
+soc-classification-utils = {path = "../soc-classification-utils", develop = true}
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.8"}
 firebase-admin = "^6.5.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ fastapi_swagger2 = "^0.2.4"
 sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.4"}
 sic-classification-utils = {git = "https://github.com/ONSdigital/sic-classification-utils.git", tag = "v0.1.13"}
 soc-classification-library = {git = "https://github.com/ONSdigital/soc-classification-library.git", tag = "v0.1.5"}
-soc-classification-utils = {path = "../soc-classification-utils", develop = true}
+soc-classification-utils = {git = "https://github.com/ONSdigital/soc-classification-utils.git", tag = "v0.1.4"}
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.8"}
 firebase-admin = "^6.5.0"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,25 +9,20 @@ Functions:
     pytest_sessionfinish(session, exitstatus): Logs the end of a test session.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
 from industrial_classification_utils.llm.llm import ClassificationLLM
+from occupational_classification_utils.llm.llm import (
+    ClassificationLLM as SOCClassificationLLM,
+)
 from survey_assist_utils.logging import get_logger
 
 from api.main import app
 from api.services.sic_lookup_client import SICLookupClient
 from api.services.sic_rephrase_client import SICRephraseClient
 from api.services.soc_lookup_client import SOCLookupClient
-from tests.soc_classify_mocks import configure_unambiguous_soc_code_mock
-
-try:
-    from occupational_classification_utils.llm.llm import (
-        ClassificationLLM as SOCClassificationLLM,
-    )
-except ImportError:
-    SOCClassificationLLM = None  # type: ignore[misc, assignment]
 
 # Configure a global logger
 logger = get_logger(__name__)
@@ -44,30 +39,9 @@ def pytest_configure(config):  # pylint: disable=unused-argument
         config (pytest.Config): The pytest configuration object containing command-line
             options and plugin configurations.
     """
-    # Mock the LLM initialisation
-    mock_llm = MagicMock(spec=ClassificationLLM)
-    mock_llm.model_name = "gemini-2.5-flash"  # Set the model name for config endpoint
-
-    # Mock the sa_rag_sic_code method to return expected values
-    mock_llm.sa_rag_sic_code.return_value = (
-        MagicMock(
-            classified=True,
-            codable=True,
-            followup=None,
-            sic_code="43210",
-            sic_descriptive="Electrical installation",
-            reasoning="Mocked reasoning",
-            sic_candidates=[
-                MagicMock(
-                    sic_code="43210",
-                    sic_descriptive="Electrical installation",
-                    likelihood=0.95,
-                )
-            ],
-        ),
-        None,
-        None,
-    )
+    # Mock SIC LLM on app state (classify tests patch unambiguous_sic_code inline).
+    mock_sic_llm = MagicMock(spec=ClassificationLLM)
+    mock_sic_llm.model_name = "gemini-2.5-flash"
 
     # Mock the SIC lookup client
     mock_sic_lookup_client = MagicMock(spec=SICLookupClient)
@@ -81,22 +55,12 @@ def pytest_configure(config):  # pylint: disable=unused-argument
     mock_sic_rephrase_client = MagicMock(spec=SICRephraseClient)
     mock_sic_rephrase_client.get_rephrased_count.return_value = 500
 
-    # Mock the SOC LLM (two-step classify: unambiguous_soc_code, then formulate_open_question).
-    mock_soc_llm = (
-        MagicMock(spec=SOCClassificationLLM)
-        if SOCClassificationLLM is not None
-        else MagicMock()
-    )
-    configure_unambiguous_soc_code_mock(mock_soc_llm)
-    mock_soc_llm.formulate_open_question = AsyncMock(
-        return_value=(
-            MagicMock(followup="Example follow-up?", reasoning="Mock follow-up."),
-            {},
-        )
-    )
+    # Mock SOC LLM on app state (classify tests patch unambiguous_soc_code inline).
+    mock_soc_llm = MagicMock(spec=SOCClassificationLLM)
+    mock_soc_llm.model_name = "gemini-2.5-flash"
 
     # Set up app state with all required clients
-    app.state.gemini_llm = mock_llm
+    app.state.gemini_llm = mock_sic_llm
     app.state.soc_llm = mock_soc_llm
     app.state.sic_lookup_client = mock_sic_lookup_client
     app.state.soc_lookup_client = mock_soc_lookup_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ from api.main import app
 from api.services.sic_lookup_client import SICLookupClient
 from api.services.sic_rephrase_client import SICRephraseClient
 from api.services.soc_lookup_client import SOCLookupClient
+from api.services.soc_rephrase_client import SOCRephraseClient
 
 # Configure a global logger
 logger = get_logger(__name__)
@@ -55,6 +56,8 @@ def pytest_configure(config):  # pylint: disable=unused-argument
     mock_sic_rephrase_client = MagicMock(spec=SICRephraseClient)
     mock_sic_rephrase_client.get_rephrased_count.return_value = 500
 
+    mock_soc_rephrase_client = MagicMock(spec=SOCRephraseClient)
+
     # Mock SOC LLM on app state (classify tests patch unambiguous_soc_code inline).
     mock_soc_llm = MagicMock(spec=SOCClassificationLLM)
     mock_soc_llm.model_name = "gemini-2.5-flash"
@@ -65,6 +68,7 @@ def pytest_configure(config):  # pylint: disable=unused-argument
     app.state.sic_lookup_client = mock_sic_lookup_client
     app.state.soc_lookup_client = mock_soc_lookup_client
     app.state.sic_rephrase_client = mock_sic_rephrase_client
+    app.state.soc_rephrase_client = mock_soc_rephrase_client
 
     logger.info("Global Test Configuration Applied")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from api.main import app
 from api.services.sic_lookup_client import SICLookupClient
 from api.services.sic_rephrase_client import SICRephraseClient
 from api.services.soc_lookup_client import SOCLookupClient
+from tests.soc_classify_mocks import configure_unambiguous_soc_code_mock
 
 try:
     from occupational_classification_utils.llm.llm import (
@@ -80,30 +81,17 @@ def pytest_configure(config):  # pylint: disable=unused-argument
     mock_sic_rephrase_client = MagicMock(spec=SICRephraseClient)
     mock_sic_rephrase_client.get_rephrased_count.return_value = 500
 
-    # Mock the SOC LLM (mirrors SIC above: single-step RAG method on app state; async).
-    # Optional import like main.py/classify.py: use SOC class as spec when available.
+    # Mock the SOC LLM (two-step classify: unambiguous_soc_code, then formulate_open_question).
     mock_soc_llm = (
         MagicMock(spec=SOCClassificationLLM)
         if SOCClassificationLLM is not None
         else MagicMock()
     )
-    mock_soc_llm.sa_rag_soc_code = AsyncMock(
+    configure_unambiguous_soc_code_mock(mock_soc_llm)
+    mock_soc_llm.formulate_open_question = AsyncMock(
         return_value=(
-            MagicMock(
-                soc_code="9111",
-                soc_descriptive="Farm workers",
-                soc_candidates=[
-                    MagicMock(
-                        soc_code="9111",
-                        soc_descriptive="Farm workers",
-                        likelihood=0.9,
-                    )
-                ],
-                followup=None,
-                reasoning="Mocked SOC reasoning",
-            ),
-            None,
-            None,
+            MagicMock(followup="Example follow-up?", reasoning="Mock follow-up."),
+            {},
         )
     )
 

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -404,6 +404,65 @@ def test_sic_formulate_open_question_llm_failure_returns_422(
 
 @patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
+def test_sic_unambiguous_returns_final_code(mock_llm, mock_vector_store):
+    """Electrician: unambiguous_sic_code returns classified=true with code 43210."""
+    mock_vector_store.return_value.search = AsyncMock(
+        return_value=[
+            {
+                "code": EXPECTED_SIC_CODE,
+                "title": EXPECTED_SIC_DESCRIPTION,
+                "distance": 0.05,
+            },
+            {
+                "code": "43220",
+                "title": "Plumbing installation",
+                "distance": 0.32,
+            },
+        ]
+    )
+    mock_llm.unambiguous_sic_code = AsyncMock(
+        return_value=(
+            MagicMock(
+                codable=True,
+                class_code=EXPECTED_SIC_CODE,
+                class_descriptive=EXPECTED_SIC_DESCRIPTION,
+                alt_candidates=[
+                    MagicMock(
+                        class_code=EXPECTED_SIC_CODE,
+                        class_descriptive=EXPECTED_SIC_DESCRIPTION,
+                        likelihood=EXPECTED_LIKELIHOOD,
+                    ),
+                    MagicMock(
+                        class_code="43220",
+                        class_descriptive="Plumbing installation",
+                        likelihood=0.1,
+                    ),
+                ],
+                reasoning="Clear electrical installation match.",
+            ),
+            None,
+        )
+    )
+    res = client.post(
+        "/v1/survey-assist/classify",
+        json={
+            "llm": "gemini",
+            "type": "sic",
+            "job_title": "Electrician",
+            "job_description": "Installing and maintaining electrical systems in buildings",
+            "org_description": "Electrical contracting company",
+            "options": {"sic": {"rephrased": False}},
+        },
+    )
+    assert res.status_code == status.HTTP_200_OK
+    out = res.json()["results"][0]
+    assert out["classified"] is True and out["code"] == EXPECTED_SIC_CODE
+    assert out["description"] == EXPECTED_SIC_DESCRIPTION and out["followup"] is None
+    mock_llm.formulate_open_question.assert_not_called()
+
+
+@patch("api.routes.v1.classify.SICVectorStoreClient")
+@patch("api.main.app.state.gemini_llm")
 def test_sic_empty_vector_store_still_calls_unambiguous(mock_llm, mock_vector_store):
     """Empty search results still run two-step flow (mirrors SOC)."""
     mock_vector_store.return_value.search = AsyncMock(return_value=[])

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -402,6 +402,52 @@ def test_sic_formulate_open_question_llm_failure_returns_422(
 
 @patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
+def test_sic_empty_vector_store_still_calls_unambiguous(mock_llm, mock_vector_store):
+    """Empty search results still run two-step flow (mirrors SOC)."""
+    mock_vector_store.return_value.search = AsyncMock(return_value=[])
+    mock_unambiguous = MagicMock(
+        codable=False,
+        class_code=None,
+        class_descriptive=None,
+        alt_candidates=[
+            MagicMock(
+                class_code=EXPECTED_SIC_CODE,
+                class_descriptive=EXPECTED_SIC_DESCRIPTION,
+                likelihood=0.5,
+            ),
+        ],
+        reasoning="No vector candidates; LLM still evaluated.",
+    )
+    mock_llm.unambiguous_sic_code = AsyncMock(return_value=(mock_unambiguous, None))
+    mock_llm.formulate_open_question = AsyncMock(
+        return_value=(
+            MagicMock(
+                followup="What is the employer's main product or service?",
+                reasoning="",
+            ),
+            None,
+        )
+    )
+    res = client.post(
+        "/v1/survey-assist/classify",
+        json={
+            "llm": "gemini",
+            "type": "sic",
+            "job_title": "Electrician",
+            "job_description": "Installing electrical systems",
+            "org_description": "Electrical contracting company",
+            "options": {"sic": {"rephrased": False}},
+        },
+    )
+    assert res.status_code == status.HTTP_200_OK
+    mock_llm.unambiguous_sic_code.assert_called_once()
+    call_kwargs = mock_llm.unambiguous_sic_code.call_args.kwargs
+    assert call_kwargs["semantic_search_results"] == []
+    mock_llm.formulate_open_question.assert_called_once()
+
+
+@patch("api.routes.v1.classify.SICVectorStoreClient")
+@patch("api.main.app.state.gemini_llm")
 @patch("api.main.app.state.sic_rephrase_client")
 @patch("google.auth.default")
 def test_classify_endpoint_success(

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -121,18 +121,17 @@ class TestClassifyEndpoint:
         self.mock_rephrase_client.return_value = mock_rephrase_instance
 
         mock_llm_instance = MagicMock()
-        mock_llm_instance.sa_rag_sic_code.return_value = (
-            MagicMock(
-                classified=True,
-                codable=True,
-                followup=None,
-                class_code=EXPECTED_SIC_CODE,
-                class_descriptive=EXPECTED_SIC_DESCRIPTION,
-                reasoning="Mocked reasoning",
-                alt_candidates=[],
-            ),
-            None,
-            None,
+        mock_llm_instance.unambiguous_sic_code = AsyncMock(
+            return_value=(
+                MagicMock(
+                    codable=True,
+                    class_code=EXPECTED_SIC_CODE,
+                    class_descriptive=EXPECTED_SIC_DESCRIPTION,
+                    alt_candidates=[],
+                    reasoning="Mocked reasoning",
+                ),
+                None,
+            )
         )
         self.mock_llm.return_value = mock_llm_instance
 
@@ -966,7 +965,10 @@ def test_classify_endpoint_meta_field_exclusion(
     side_effect=AssertionError("SOC classify must not use Excel loaders"),
 )
 @patch("api.routes.v1.classify.SOCVectorStoreClient")
-def test_soc_classify_does_not_require_excel(mock_soc_vector_store, _mock_read_excel):
+@patch("api.main.app.state.soc_llm")
+def test_soc_classify_does_not_require_excel(
+    mock_soc_llm, mock_soc_vector_store, _mock_read_excel
+):
     """SOC classify works even when Excel loaders are unavailable."""
     mock_soc_vector_store.return_value.search = AsyncMock(
         return_value=[
@@ -976,6 +978,24 @@ def test_soc_classify_does_not_require_excel(mock_soc_vector_store, _mock_read_e
                 "distance": 0.05,
             }
         ]
+    )
+    mock_soc_llm.unambiguous_soc_code = AsyncMock(
+        return_value=(
+            MagicMock(
+                codable=True,
+                class_code=EXPECTED_SOC_CODE,
+                class_descriptive=EXPECTED_SOC_DESCRIPTION,
+                alt_candidates=[
+                    MagicMock(
+                        class_code=EXPECTED_SOC_CODE,
+                        class_descriptive=EXPECTED_SOC_DESCRIPTION,
+                        likelihood=EXPECTED_LIKELIHOOD,
+                    )
+                ],
+                reasoning="Mocked SOC reasoning for excel guard test.",
+            ),
+            None,
+        )
     )
 
     request_data = {
@@ -1007,23 +1027,22 @@ def test_soc_classify_rephrases_by_default(mock_soc_llm, mock_soc_vector_store):
             }
         ]
     )
-    mock_soc_llm.sa_rag_soc_code = AsyncMock(
+    mock_soc_llm.unambiguous_soc_code = AsyncMock(
         return_value=(
             MagicMock(
-                soc_code=EXPECTED_SOC_CODE,
-                soc_descriptive="Elementary occupations",
-                soc_candidates=[
+                codable=True,
+                class_code=EXPECTED_SOC_CODE,
+                class_descriptive="Elementary occupations",
+                alt_candidates=[
                     MagicMock(
-                        soc_code=EXPECTED_SOC_CODE,
-                        soc_descriptive="Elementary occupations",
+                        class_code=EXPECTED_SOC_CODE,
+                        class_descriptive="Elementary occupations",
                         likelihood=EXPECTED_LIKELIHOOD,
                     )
                 ],
-                followup=None,
-                reasoning="Mocked SOC reasoning",
+                reasoning="Mocked SOC reasoning for rephrase test with enough detail.",
             ),
-            None,
-            None,
+            {},
         )
     )
     mock_soc_rephrase_client = MagicMock()
@@ -1063,23 +1082,22 @@ def test_soc_classify_rephrased_false_keeps_original_descriptions(
             }
         ]
     )
-    mock_soc_llm.sa_rag_soc_code = AsyncMock(
+    mock_soc_llm.unambiguous_soc_code = AsyncMock(
         return_value=(
             MagicMock(
-                soc_code=EXPECTED_SOC_CODE,
-                soc_descriptive="Elementary occupations",
-                soc_candidates=[
+                codable=True,
+                class_code=EXPECTED_SOC_CODE,
+                class_descriptive="Elementary occupations",
+                alt_candidates=[
                     MagicMock(
-                        soc_code=EXPECTED_SOC_CODE,
-                        soc_descriptive="Elementary occupations",
+                        class_code=EXPECTED_SOC_CODE,
+                        class_descriptive="Elementary occupations",
                         likelihood=EXPECTED_LIKELIHOOD,
                     )
                 ],
-                followup=None,
-                reasoning="Mocked SOC reasoning",
+                reasoning="Mocked SOC reasoning for rephrase false test with detail.",
             ),
-            None,
-            None,
+            {},
         )
     )
     mock_soc_rephrase_client = MagicMock()
@@ -1105,38 +1123,35 @@ def test_soc_classify_rephrased_false_keeps_original_descriptions(
     assert first["candidates"][0]["descriptive"] == "Elementary occupations"
 
 
-def _sa673_llm_no_code_tuple(candidates, followup):
-    """SA-673 mock LLM return, no final ``soc_code`` (same tuple shape as ``sa_rag_soc_code``)."""
-    return (
-        MagicMock(
-            soc_code=None,
-            soc_descriptive=None,
-            soc_candidates=candidates,
-            followup=followup,
-            reasoning="",
-        ),
-        None,
-        None,
-    )
-
-
 @patch("api.routes.v1.classify.SOCVectorStoreClient")
 @patch("api.main.app.state.soc_llm")
-def test_soc_promotes_clear_likelihood_winner(mock_soc_llm, mock_soc_vector_store):
-    """SA-673: dominant likelihood → final code when the LLM omits ``soc_code``."""
+def test_soc_unambiguous_returns_final_code(mock_soc_llm, mock_soc_vector_store):
+    """Farm hand: unambiguous_soc_code returns classified=true with code 9111."""
     mock_soc_vector_store.return_value.search = AsyncMock(
         return_value=[
-            {"code": "9111", "title": "a", "distance": 0.05},
-            {"code": "5111", "title": "b", "distance": 0.32},
+            {"code": "9111", "title": "Farm workers", "distance": 0.05},
+            {"code": "5111", "title": "Other", "distance": 0.32},
         ]
     )
-    mock_soc_llm.sa_rag_soc_code = AsyncMock(
-        return_value=_sa673_llm_no_code_tuple(
-            [
-                MagicMock(soc_code="9111", soc_descriptive="Winner", likelihood=0.9),
-                MagicMock(soc_code="5111", soc_descriptive="Runner", likelihood=0.1),
-            ],
-            "ignored when promoted",
+    mock_soc_llm.unambiguous_soc_code = AsyncMock(
+        return_value=(
+            MagicMock(
+                codable=True,
+                class_code="9111",
+                class_descriptive="Farm workers",
+                alt_candidates=[
+                    MagicMock(
+                        class_code="9111",
+                        class_descriptive="Farm workers",
+                        likelihood=0.9,
+                    ),
+                    MagicMock(
+                        class_code="5111", class_descriptive="Other", likelihood=0.1
+                    ),
+                ],
+                reasoning="Clear farm worker match.",
+            ),
+            None,
         )
     )
     res = client.post(
@@ -1153,13 +1168,14 @@ def test_soc_promotes_clear_likelihood_winner(mock_soc_llm, mock_soc_vector_stor
     assert res.status_code == status.HTTP_200_OK
     out = res.json()["results"][0]
     assert out["classified"] is True and out["code"] == "9111"
-    assert out["description"] == "Winner" and out["followup"] is None
+    assert out["description"] == "Farm workers" and out["followup"] is None
+    mock_soc_llm.formulate_open_question.assert_not_called()
 
 
 @patch("api.routes.v1.classify.SOCVectorStoreClient")
 @patch("api.main.app.state.soc_llm")
 def test_soc_ambiguous_keeps_followup(mock_soc_llm, mock_soc_vector_store):
-    """SA-673: tight likelihoods → stay unclassified; follow-up unchanged."""
+    """Ambiguous case: formulate_open_question supplies follow-up."""
     follow = "Still need detail?"
     mock_soc_vector_store.return_value.search = AsyncMock(
         return_value=[
@@ -1167,14 +1183,19 @@ def test_soc_ambiguous_keeps_followup(mock_soc_llm, mock_soc_vector_store):
             {"code": "5111", "title": "b", "distance": 0.19},
         ]
     )
-    mock_soc_llm.sa_rag_soc_code = AsyncMock(
-        return_value=_sa673_llm_no_code_tuple(
-            [
-                MagicMock(soc_code="9111", soc_descriptive="A", likelihood=0.56),
-                MagicMock(soc_code="5111", soc_descriptive="B", likelihood=0.49),
-            ],
-            follow,
-        )
+    mock_unambiguous = MagicMock(
+        codable=False,
+        class_code=None,
+        class_descriptive=None,
+        alt_candidates=[
+            MagicMock(class_code="9111", class_descriptive="A", likelihood=0.56),
+            MagicMock(class_code="5111", class_descriptive="B", likelihood=0.49),
+        ],
+        reasoning="Ambiguous shortlist.",
+    )
+    mock_soc_llm.unambiguous_soc_code = AsyncMock(return_value=(mock_unambiguous, None))
+    mock_soc_llm.formulate_open_question = AsyncMock(
+        return_value=(MagicMock(followup=follow, reasoning="Need more detail."), None)
     )
     res = client.post(
         "/v1/survey-assist/classify",

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -1174,8 +1174,8 @@ def test_soc_unambiguous_returns_final_code(mock_soc_llm, mock_soc_vector_store)
 
 @patch("api.routes.v1.classify.SOCVectorStoreClient")
 @patch("api.main.app.state.soc_llm")
-def test_soc_ambiguous_keeps_followup(mock_soc_llm, mock_soc_vector_store):
-    """Ambiguous case: formulate_open_question supplies follow-up."""
+def test_soc_not_codable_returns_followup(mock_soc_llm, mock_soc_vector_store):
+    """When unambiguous_soc_code sets codable false, formulate_open_question supplies followup."""
     follow = "Still need detail?"
     mock_soc_vector_store.return_value.search = AsyncMock(
         return_value=[
@@ -1216,6 +1216,7 @@ def test_soc_ambiguous_keeps_followup(mock_soc_llm, mock_soc_vector_store):
         and out["description"] is None
     )
     assert out["followup"] == follow
+    mock_soc_llm.formulate_open_question.assert_called_once()
 
 
 @patch("api.routes.v1.classify.SOCVectorStoreClient")

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -37,6 +37,8 @@ from fastapi.testclient import TestClient
 from survey_assist_utils.logging import get_logger
 
 from api.main import app
+from api.models.classify import ClassificationRequest
+from api.routes.v1.classify import _classify_body_id
 
 logger = get_logger(__name__)
 client = TestClient(app)
@@ -443,22 +445,25 @@ def test_sic_unambiguous_returns_final_code(mock_llm, mock_vector_store):
             None,
         )
     )
-    res = client.post(
-        "/v1/survey-assist/classify",
-        json={
-            "llm": "gemini",
-            "type": "sic",
-            "job_title": "Electrician",
-            "job_description": "Installing and maintaining electrical systems in buildings",
-            "org_description": "Electrical contracting company",
-            "options": {"sic": {"rephrased": False}},
-        },
-    )
+    request_json = {
+        "llm": "gemini",
+        "type": "sic",
+        "job_title": "Electrician",
+        "job_description": "Installing and maintaining electrical systems in buildings",
+        "org_description": "Electrical contracting company",
+        "options": {"sic": {"rephrased": False}},
+    }
+    expected_body_id = _classify_body_id(ClassificationRequest.model_validate(request_json))
+    res = client.post("/v1/survey-assist/classify", json=request_json)
     assert res.status_code == status.HTTP_200_OK
     out = res.json()["results"][0]
     assert out["classified"] is True and out["code"] == EXPECTED_SIC_CODE
     assert out["description"] == EXPECTED_SIC_DESCRIPTION and out["followup"] is None
     mock_llm.formulate_open_question.assert_not_called()
+    assert (
+        mock_llm.unambiguous_sic_code.call_args.kwargs["correlation_id"]
+        == expected_body_id
+    )
 
 
 @patch("api.routes.v1.classify.SICVectorStoreClient")
@@ -1351,22 +1356,25 @@ def test_soc_unambiguous_returns_final_code(mock_soc_llm, mock_soc_vector_store)
             None,
         )
     )
-    res = client.post(
-        "/v1/survey-assist/classify",
-        json={
-            "llm": "gemini",
-            "type": "soc",
-            "job_title": "farm hand",
-            "job_description": "Basic supervised manual work.",
-            "org_description": "farming",
-            "options": {"soc": {"rephrased": False}},
-        },
-    )
+    request_json = {
+        "llm": "gemini",
+        "type": "soc",
+        "job_title": "farm hand",
+        "job_description": "Basic supervised manual work.",
+        "org_description": "farming",
+        "options": {"soc": {"rephrased": False}},
+    }
+    expected_body_id = _classify_body_id(ClassificationRequest.model_validate(request_json))
+    res = client.post("/v1/survey-assist/classify", json=request_json)
     assert res.status_code == status.HTTP_200_OK
     out = res.json()["results"][0]
     assert out["classified"] is True and out["code"] == "9111"
     assert out["description"] == "Farm workers" and out["followup"] is None
     mock_soc_llm.formulate_open_question.assert_not_called()
+    assert (
+        mock_soc_llm.unambiguous_soc_code.call_args.kwargs["correlation_id"]
+        == expected_body_id
+    )
 
 
 @patch("api.routes.v1.classify.SOCVectorStoreClient")

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -1311,24 +1311,35 @@ def test_soc_unambiguous_returns_final_code(mock_soc_llm, mock_soc_vector_store)
 @patch("api.routes.v1.classify.SOCVectorStoreClient")
 @patch("api.main.app.state.soc_llm")
 def test_soc_not_codable_returns_followup(mock_soc_llm, mock_soc_vector_store):
-    """When unambiguous_soc_code sets codable false, formulate_open_question supplies followup."""
+    """When unambiguous_soc_code sets codable false, formulate_open_question supplies followup.
+
+    Mirrors ``test_classify_followup_question``: all ``alt_candidates`` are passed to
+    ``formulate_open_question``, not only the first.
+    """
     follow = "Still need detail?"
     mock_soc_vector_store.return_value.search = AsyncMock(
         return_value=[
-            {"code": "9111", "title": "a", "distance": 0.15},
-            {"code": "5111", "title": "b", "distance": 0.19},
+            {"code": "9111", "title": "Farm workers", "distance": 0.15},
+            {"code": "5111", "title": "Other agricultural", "distance": 0.19},
+            {"code": "9112", "title": "Other farm workers", "distance": 0.22},
         ]
     )
     mock_unambiguous = MagicMock(
         codable=False,
         class_code=None,
         class_descriptive=None,
-        alt_candidates=[
-            MagicMock(class_code="9111", class_descriptive="A", likelihood=0.56),
-            MagicMock(class_code="5111", class_descriptive="B", likelihood=0.49),
-        ],
         reasoning="Ambiguous shortlist.",
     )
+    candidate1 = MagicMock(class_code="9111", class_descriptive="Farm workers", likelihood=0.56)
+    candidate2 = MagicMock(
+        class_code="5111", class_descriptive="Other agricultural", likelihood=0.49
+    )
+    candidate3 = MagicMock(
+        class_code="9112", class_descriptive="Other farm workers", likelihood=0.45
+    )
+    mock_unambiguous.alt_candidates = [candidate1, candidate2, candidate3]
+    expected_candidates_count = len(mock_unambiguous.alt_candidates)
+
     mock_soc_llm.unambiguous_soc_code = AsyncMock(return_value=(mock_unambiguous, None))
     mock_soc_llm.formulate_open_question = AsyncMock(
         return_value=(MagicMock(followup=follow, reasoning="Need more detail."), None)
@@ -1352,9 +1363,21 @@ def test_soc_not_codable_returns_followup(mock_soc_llm, mock_soc_vector_store):
         and out["description"] is None
     )
     assert out["followup"] == follow
-    mock_soc_llm.formulate_open_question.assert_called_once()
+    assert len(out["candidates"]) == expected_candidates_count
+
+    assert mock_soc_llm.formulate_open_question.called
     call_args = mock_soc_llm.formulate_open_question.call_args
-    assert call_args.kwargs.get("llm_output") == mock_unambiguous.alt_candidates
+    assert call_args is not None
+    llm_output = call_args.kwargs.get("llm_output")
+    assert llm_output == mock_unambiguous.alt_candidates, (
+        "formulate_open_question should receive the full list of candidates, "
+        f"not just the first one. Expected {len(mock_unambiguous.alt_candidates)} "
+        f"candidates, got {len(llm_output) if llm_output else 0}"
+    )
+    assert len(llm_output) == expected_candidates_count, (
+        f"Expected {expected_candidates_count} candidates to be passed, "
+        f"got {len(llm_output)}"
+    )
 
 
 @patch("api.routes.v1.classify.SOCVectorStoreClient")

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -1336,7 +1336,7 @@ def test_soc_unambiguous_llm_failure_returns_422(mock_soc_llm, mock_soc_vector_s
             "options": {"soc": {"rephrased": False}},
         },
     )
-    _assert_llm_classification_422(response, "Unambiguous SOC classification failed")
+    _assert_llm_classification_422(response, "Unambiguous classification failed")
     mock_soc_llm.formulate_open_question.assert_not_called()
 
 

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -1216,3 +1216,44 @@ def test_soc_ambiguous_keeps_followup(mock_soc_llm, mock_soc_vector_store):
         and out["description"] is None
     )
     assert out["followup"] == follow
+
+
+@patch("api.routes.v1.classify.SOCVectorStoreClient")
+@patch("api.main.app.state.soc_llm")
+def test_soc_empty_vector_store_still_calls_unambiguous(
+    mock_soc_llm, mock_soc_vector_store
+):
+    """Empty search results still run two-step flow (mirrors SIC)."""
+    mock_soc_vector_store.return_value.search = AsyncMock(return_value=[])
+    mock_unambiguous = MagicMock(
+        codable=False,
+        class_code=None,
+        class_descriptive=None,
+        alt_candidates=[
+            MagicMock(class_code="9111", class_descriptive="A", likelihood=0.5),
+        ],
+        reasoning="No vector candidates; LLM still evaluated.",
+    )
+    mock_soc_llm.unambiguous_soc_code = AsyncMock(return_value=(mock_unambiguous, None))
+    mock_soc_llm.formulate_open_question = AsyncMock(
+        return_value=(
+            MagicMock(followup="What are your main tasks?", reasoning=""),
+            None,
+        )
+    )
+    res = client.post(
+        "/v1/survey-assist/classify",
+        json={
+            "llm": "gemini",
+            "type": "soc",
+            "job_title": "farm hand",
+            "job_description": "Varied farm work.",
+            "org_description": "farming",
+            "options": {"soc": {"rephrased": False}},
+        },
+    )
+    assert res.status_code == status.HTTP_200_OK
+    mock_soc_llm.unambiguous_soc_code.assert_called_once()
+    call_kwargs = mock_soc_llm.unambiguous_soc_code.call_args.kwargs
+    assert call_kwargs["semantic_search_results"] == []
+    mock_soc_llm.formulate_open_question.assert_called_once()

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -339,7 +339,9 @@ def test_classify_followup_question(  # pylint: disable=too-many-locals
 @patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
-def test_sic_unambiguous_llm_failure_returns_422(mock_auth, mock_llm, mock_vector_store):
+def test_sic_unambiguous_llm_failure_returns_422(
+    mock_auth, mock_llm, mock_vector_store
+):
     """Step 1 LLM failure returns 422 with unambiguous error details."""
     mock_auth.return_value = (MagicMock(), "test-project")
     mock_vector_store.return_value.search = AsyncMock(
@@ -1330,7 +1332,9 @@ def test_soc_not_codable_returns_followup(mock_soc_llm, mock_soc_vector_store):
         class_descriptive=None,
         reasoning="Ambiguous shortlist.",
     )
-    candidate1 = MagicMock(class_code="9111", class_descriptive="Farm workers", likelihood=0.56)
+    candidate1 = MagicMock(
+        class_code="9111", class_descriptive="Farm workers", likelihood=0.56
+    )
     candidate2 = MagicMock(
         class_code="5111", class_descriptive="Other agricultural", likelihood=0.49
     )

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -1217,6 +1217,8 @@ def test_soc_not_codable_returns_followup(mock_soc_llm, mock_soc_vector_store):
     )
     assert out["followup"] == follow
     mock_soc_llm.formulate_open_question.assert_called_once()
+    call_args = mock_soc_llm.formulate_open_question.call_args
+    assert call_args.kwargs.get("llm_output") == mock_unambiguous.alt_candidates
 
 
 @patch("api.routes.v1.classify.SOCVectorStoreClient")

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -1017,7 +1017,7 @@ def test_soc_classify_does_not_require_excel(
 @patch("api.routes.v1.classify.SOCVectorStoreClient")
 @patch("api.main.app.state.soc_llm")
 def test_soc_classify_rephrases_by_default(mock_soc_llm, mock_soc_vector_store):
-    """SOC rephrasing defaults to enabled when options are omitted (mirrors SIC)."""
+    """SOC rephrasing defaults on and applies to candidates only (mirrors SIC)."""
     mock_soc_vector_store.return_value.search = AsyncMock(
         return_value=[
             {
@@ -1063,7 +1063,7 @@ def test_soc_classify_rephrases_by_default(mock_soc_llm, mock_soc_vector_store):
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
     first = data["results"][0]
-    assert first["description"] == EXPECTED_SOC_DESCRIPTION
+    assert first["description"] == "Elementary occupations"
     assert first["candidates"][0]["descriptive"] == EXPECTED_SOC_DESCRIPTION
 
 

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -453,7 +453,9 @@ def test_sic_unambiguous_returns_final_code(mock_llm, mock_vector_store):
         "org_description": "Electrical contracting company",
         "options": {"sic": {"rephrased": False}},
     }
-    expected_body_id = _classify_body_id(ClassificationRequest.model_validate(request_json))
+    expected_body_id = _classify_body_id(
+        ClassificationRequest.model_validate(request_json)
+    )
     res = client.post("/v1/survey-assist/classify", json=request_json)
     assert res.status_code == status.HTTP_200_OK
     out = res.json()["results"][0]
@@ -1364,7 +1366,9 @@ def test_soc_unambiguous_returns_final_code(mock_soc_llm, mock_soc_vector_store)
         "org_description": "farming",
         "options": {"soc": {"rephrased": False}},
     }
-    expected_body_id = _classify_body_id(ClassificationRequest.model_validate(request_json))
+    expected_body_id = _classify_body_id(
+        ClassificationRequest.model_validate(request_json)
+    )
     res = client.post("/v1/survey-assist/classify", json=request_json)
     assert res.status_code == status.HTTP_200_OK
     out = res.json()["results"][0]

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -49,6 +49,32 @@ EXPECTED_SOC_CODE = "9111"
 EXPECTED_SOC_DESCRIPTION = "Farm workers"
 EXPECTED_COMBINED_RESULTS_COUNT = 2  # SIC + SOC results
 
+_LLM_STEP_ERROR = RuntimeError("mock llm step failure")
+
+
+def _assert_llm_classification_422(response, expected_details_fragment: str) -> None:
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    error = response.json()["detail"]["error"]
+    assert error["type"] == "classification_error"
+    assert error["message"] == "The LLM could not generate a valid classification"
+    assert expected_details_fragment in error["details"]
+
+
+def _mock_not_codable_unambiguous():
+    mock = MagicMock()
+    mock.codable = False
+    mock.class_code = None
+    mock.class_descriptive = None
+    mock.alt_candidates = [
+        MagicMock(
+            class_code=EXPECTED_SIC_CODE,
+            class_descriptive=EXPECTED_SIC_DESCRIPTION,
+            likelihood=0.5,
+        ),
+    ]
+    mock.reasoning = "Not codable for LLM error test."
+    return mock
+
 
 class TestClassifyEndpoint:
     """Test class for the classification endpoint."""
@@ -308,6 +334,70 @@ def test_classify_followup_question(  # pylint: disable=too-many-locals
     assert (
         len(llm_output) == expected_candidates_count
     ), f"Expected {expected_candidates_count} candidates to be passed, got {len(llm_output)}"
+
+
+@patch("api.routes.v1.classify.SICVectorStoreClient")
+@patch("api.main.app.state.gemini_llm")
+@patch("google.auth.default")
+def test_sic_unambiguous_llm_failure_returns_422(mock_auth, mock_llm, mock_vector_store):
+    """Step 1 LLM failure returns 422 with unambiguous error details."""
+    mock_auth.return_value = (MagicMock(), "test-project")
+    mock_vector_store.return_value.search = AsyncMock(
+        return_value=[
+            {
+                "code": EXPECTED_SIC_CODE,
+                "title": EXPECTED_SIC_DESCRIPTION,
+                "distance": 0.05,
+            }
+        ]
+    )
+    mock_llm.unambiguous_sic_code = AsyncMock(side_effect=_LLM_STEP_ERROR)
+    response = client.post(
+        "/v1/survey-assist/classify",
+        json={
+            "llm": "gemini",
+            "type": "sic",
+            "job_title": "Electrician",
+            "job_description": "Installing electrical systems",
+            "org_description": "Electrical contracting company",
+        },
+    )
+    _assert_llm_classification_422(response, "Unambiguous classification failed")
+    mock_llm.formulate_open_question.assert_not_called()
+
+
+@patch("api.routes.v1.classify.SICVectorStoreClient")
+@patch("api.main.app.state.gemini_llm")
+@patch("google.auth.default")
+def test_sic_formulate_open_question_llm_failure_returns_422(
+    mock_auth, mock_llm, mock_vector_store
+):
+    """Step 2 LLM failure returns 422 with open question error details."""
+    mock_auth.return_value = (MagicMock(), "test-project")
+    mock_vector_store.return_value.search = AsyncMock(
+        return_value=[
+            {
+                "code": EXPECTED_SIC_CODE,
+                "title": EXPECTED_SIC_DESCRIPTION,
+                "distance": 0.05,
+            }
+        ]
+    )
+    mock_llm.unambiguous_sic_code = AsyncMock(
+        return_value=(_mock_not_codable_unambiguous(), None)
+    )
+    mock_llm.formulate_open_question = AsyncMock(side_effect=_LLM_STEP_ERROR)
+    response = client.post(
+        "/v1/survey-assist/classify",
+        json={
+            "llm": "gemini",
+            "type": "sic",
+            "job_title": "Electrician",
+            "job_description": "Installing electrical systems",
+            "org_description": "Electrical contracting company",
+        },
+    )
+    _assert_llm_classification_422(response, "Open question formulation failed")
 
 
 @patch("api.routes.v1.classify.SICVectorStoreClient")
@@ -1219,6 +1309,68 @@ def test_soc_not_codable_returns_followup(mock_soc_llm, mock_soc_vector_store):
     mock_soc_llm.formulate_open_question.assert_called_once()
     call_args = mock_soc_llm.formulate_open_question.call_args
     assert call_args.kwargs.get("llm_output") == mock_unambiguous.alt_candidates
+
+
+@patch("api.routes.v1.classify.SOCVectorStoreClient")
+@patch("api.main.app.state.soc_llm")
+def test_soc_unambiguous_llm_failure_returns_422(mock_soc_llm, mock_soc_vector_store):
+    """Step 1 LLM failure returns 422 with unambiguous SOC error details."""
+    mock_soc_vector_store.return_value.search = AsyncMock(
+        return_value=[
+            {
+                "code": EXPECTED_SOC_CODE,
+                "title": EXPECTED_SOC_DESCRIPTION,
+                "distance": 0.05,
+            }
+        ]
+    )
+    mock_soc_llm.unambiguous_soc_code = AsyncMock(side_effect=_LLM_STEP_ERROR)
+    response = client.post(
+        "/v1/survey-assist/classify",
+        json={
+            "llm": "gemini",
+            "type": "soc",
+            "job_title": "farm hand",
+            "job_description": "Varied farm work.",
+            "org_description": "farming",
+            "options": {"soc": {"rephrased": False}},
+        },
+    )
+    _assert_llm_classification_422(response, "Unambiguous SOC classification failed")
+    mock_soc_llm.formulate_open_question.assert_not_called()
+
+
+@patch("api.routes.v1.classify.SOCVectorStoreClient")
+@patch("api.main.app.state.soc_llm")
+def test_soc_formulate_open_question_llm_failure_returns_422(
+    mock_soc_llm, mock_soc_vector_store
+):
+    """Step 2 LLM failure returns 422 with open question error details."""
+    mock_soc_vector_store.return_value.search = AsyncMock(
+        return_value=[
+            {
+                "code": EXPECTED_SOC_CODE,
+                "title": EXPECTED_SOC_DESCRIPTION,
+                "distance": 0.05,
+            }
+        ]
+    )
+    mock_soc_llm.unambiguous_soc_code = AsyncMock(
+        return_value=(_mock_not_codable_unambiguous(), None)
+    )
+    mock_soc_llm.formulate_open_question = AsyncMock(side_effect=_LLM_STEP_ERROR)
+    response = client.post(
+        "/v1/survey-assist/classify",
+        json={
+            "llm": "gemini",
+            "type": "soc",
+            "job_title": "farm hand",
+            "job_description": "Varied farm work.",
+            "org_description": "farming",
+            "options": {"soc": {"rephrased": False}},
+        },
+    )
+    _assert_llm_classification_422(response, "Open question formulation failed")
 
 
 @patch("api.routes.v1.classify.SOCVectorStoreClient")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -102,7 +102,11 @@ def test_get_config(test_client):
         "SIC_PROMPT_UNAMBIGUOUS",
         "SIC_PROMPT_OPENFOLLOWUP",
     }
-    assert v3_types["soc"] == {"SOC_PROMPT_UNAMBIGUOUS", "SOC_PROMPT_OPENFOLLOWUP"}
+    assert v3_types["soc"] == {
+        "SA_SOC_PROMPT_RAG",
+        "SOC_PROMPT_UNAMBIGUOUS",
+        "SOC_PROMPT_OPENFOLLOWUP",
+    }
 
     v1v2_types = {entry["type"] for entry in response.json()["v1v2"]["classification"]}
     assert v1v2_types == {"sic", "soc"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -93,6 +93,16 @@ def test_get_config(test_client):
     assert "actual_prompt" in response.json()
     assert isinstance(response.json()["actual_prompt"], str)
 
+    v3_types = {
+        entry["type"]: {p["name"] for p in entry["prompts"]}
+        for entry in response.json()["v3"]["classification"]
+    }
+    assert v3_types["sic"] == {"SIC_PROMPT_RERANKER", "SIC_PROMPT_UNAMBIGUOUS"}
+    assert v3_types["soc"] == {"SOC_PROMPT_UNAMBIGUOUS", "SOC_PROMPT_OPENFOLLOWUP"}
+
+    v1v2_types = {entry["type"] for entry in response.json()["v1v2"]["classification"]}
+    assert v1v2_types == {"sic", "soc"}
+
 
 @pytest.mark.api
 @pytest.mark.asyncio

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -97,7 +97,11 @@ def test_get_config(test_client):
         entry["type"]: {p["name"] for p in entry["prompts"]}
         for entry in response.json()["v3"]["classification"]
     }
-    assert v3_types["sic"] == {"SIC_PROMPT_RERANKER", "SIC_PROMPT_UNAMBIGUOUS"}
+    assert v3_types["sic"] == {
+        "SIC_PROMPT_RERANKER",
+        "SIC_PROMPT_UNAMBIGUOUS",
+        "SIC_PROMPT_OPENFOLLOWUP",
+    }
     assert v3_types["soc"] == {"SOC_PROMPT_UNAMBIGUOUS", "SOC_PROMPT_OPENFOLLOWUP"}
 
     v1v2_types = {entry["type"] for entry in response.json()["v1v2"]["classification"]}


### PR DESCRIPTION

# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

Aligns SOC classify with the existing SIC two-step flow: vector store search, then `unambiguous_soc_code`, then `formulate_open_question` only when the first step is not codable. Removes SA-673 single-step RAG and API-side clear-winner promotion from the classify route. Refactors `classify.py` for lint limits without changing behaviour, and exposes SOC/SIC classify prompt names on the config endpoint for operators.

**Depends on:** `soc-classification-utils` branch `SA-693/two-step-classify` (local `develop` path in `pyproject.toml` until a tagged release is published and pinned).

> **CI note:** CI is currently failing because `pyproject.toml` points `soc-classification-utils` at a local path (`../soc-classification-utils`). This is expected until the utils SA-693 PR is merged and a new tag is published; this PR should then pin that tag and CI should pass.

## 📜 Changes Introduced

- [x] Feature implementation (feat:) / bug fix (fix:) / refactoring (chore:) / documentation (docs:) / testing (test:)
- [x] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable)

- `api/routes/v1/classify.py`: `_classify_soc` mirrors `_classify_sic` (`unambiguous_soc_code` → optional `formulate_open_question`); removed `sa_rag_soc_code`, `_select_soc_clear_winner`, and SA-673 likelihood thresholds; passes `correlation_id=body_id` on all classify LLM calls; route split into helpers/`ClassifyClients` for Ruff/Pylint.
- `api/routes/v1/config.py`: SOC v3 prompts (`SOC_PROMPT_UNAMBIGUOUS`, `SOC_PROMPT_OPENFOLLOWUP`, `SA_SOC_PROMPT_RAG`); SIC v3 adds `SIC_PROMPT_OPENFOLLOWUP` for parity.
- `tests/test_classify.py`: SOC two-step unit tests (farm hand `9111`, ambiguous follow-up, LLM failure 422s, empty vector store, correlation_id); removed SA-673 promotion tests; SIC unambiguous codable test added.
- `docs/generic_classification.md`, `docs/guide.md`: document SOC two-step classify and config prompt names.
- `pyproject.toml` / `poetry.lock`: editable `soc-classification-utils` for local SA-693 work (replace with Git tag before merge).

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

### Prerequisites

1. PR [`soc-classification-utils`](https://github.com/ONSdigital/soc-classification-utils/pull/29) on branch `SA-693/two-step-classify`.

2. `soc-classification-vector-store` cloned and connected to the same local utils (not only the published Git tag):

   - Check out the vector-store repo (sibling to `soc-classification-utils`).
   - In `soc-classification-vector-store/pyproject.toml`, set the utils dependency to the editable local path (same pattern as survey-assist-api):

     ```toml
     soc-classification-utils = { path = "../soc-classification-utils", develop = true }
     ```

   - Refresh the lockfile and install:

     ```bash
     cd soc-classification-vector-store
     poetry lock
     poetry install
     make run-vector-store   # http://localhost:8089
     ```

   - Confirm status: `curl -s http://localhost:8089/v1/soc-vector-store/status` → `"status": "ready"`.

3. `survey-assist-api`: same editable utils path in `pyproject.toml`, then `poetry lock && poetry install`. Export sandbox lookup/rephrase paths before `make run-api` (port `8080`):

   ```bash
   export SIC_LOOKUP_DATA_PATH="data/sic_kb_for_direct_lookup.csv"
   export SIC_REPHRASE_DATA_PATH="data/sic_rephrased.csv"
   export SOC_LOOKUP_DATA_PATH="data/soc_kb_for_direct_lookup.csv"
   export SOC_REPHRASE_DATA_PATH="data/soc_rephrased.csv"
   ```

### Unit tests

```bash
cd survey-assist-api
poetry install
poetry run pytest tests/test_classify.py tests/test_main.py -q
make check-python-nofix
```

**Verified:** `29 passed`

### Live classify (two-step)

**Clear / codable (step 1 only — no follow-up):**

```bash
curl -s -X POST http://127.0.0.1:8080/v1/survey-assist/classify \
  -H "Content-Type: application/json" \
  -d '{
    "llm": "gemini",
    "type": "soc",
    "job_title": "farm hand",
    "job_description": "Manual labour under supervision that requires basic routine tasks only. All of my tasks require minimal training.",
    "org_description": "farming"
  }'
```

**Expected:** HTTP `200`, `results[0].classified` `true`, `code` `9111`, `followup` `null`.

**Verified** (sandbox CSVs in `data/`): `classified: true`, `code: "9111"`, `description: "Elementary occupations"`.

**Another codable example:**

```bash
curl -s -X POST http://127.0.0.1:8080/v1/survey-assist/classify \
  -H "Content-Type: application/json" \
  -d '{
    "llm": "gemini",
    "type": "soc",
    "job_title": "school teacher",
    "job_description": "teach maths to secondary pupils",
    "org_description": "secondary school"
  }'
```

**Verified** (sandbox CSVs in `data/`): `classified: true`, `code: "2313"`, `description: "Professional occupations"`.

**Ambiguous (step 2 — follow-up question):**

```bash
curl -s -X POST http://127.0.0.1:8080/v1/survey-assist/classify \
  -H "Content-Type: application/json" \
  -d '{
    "llm": "gemini",
    "type": "soc",
    "job_title": "manager",
    "job_description": "I manage people and operations",
    "org_description": "various"
  }'
```

**Expected:** HTTP `200`, `classified` `false`, `code` `null`, non-empty `followup`.

**Verified** (sandbox CSVs in `data/`): `classified: false`, `followup: "What are your main daily tasks and responsibilities?"`.

