### PR TITLE
SA-653/migrate sic data access to library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7606,7 +7606,7 @@ files = [
 
 [[package]]
 name = "sic-classification-library"
-version = "0.1.3"
+version = "0.1.5"
 description = "Standard Industrial Classification library"
 optional = false
 python-versions = "^3.12"
@@ -7615,18 +7615,19 @@ files = []
 develop = false
 
 [package.dependencies]
+openpyxl = "^3.1.5"
 pandas = "^2.3.0"
 pydantic = "^2.11.7"
 
 [package.source]
 type = "git"
 url = "https://github.com/ONSdigital/sic-classification-library.git"
-reference = "v0.1.4"
-resolved_reference = "2f2592dfc501ea48ee1fb0a9a452bbea2e3642c1"
+reference = "v0.1.5"
+resolved_reference = "92fb9a7a50d6b46cea0ed06fc0fd3082c8677828"
 
 [[package]]
 name = "sic-classification-utils"
-version = "0.1.13"
+version = "0.1.14"
 description = "Utility functions used for SIC classification"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -7648,14 +7649,14 @@ pandas = "^2.3.0"
 pydantic = "^2.11.1"
 scikit-learn = "^1.3.0"
 scipy = "^1.15.0"
-sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.4"}
+sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.5"}
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.8"}
 
 [package.source]
 type = "git"
 url = "https://github.com/ONSdigital/sic-classification-utils.git"
-reference = "v0.1.13"
-resolved_reference = "0de9621707484fd29e996d7c8dbb43fe4a9b8183"
+reference = "v0.1.14"
+resolved_reference = "7f8303fac666976440c3bea93f2203f029c5c148"
 
 [[package]]
 name = "six"
@@ -9118,4 +9119,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "c10fc9cb4529a40bcbfe3f5e9e7300ce7a7483ea76cab589a4c5bef491e1f5b7"
+content-hash = "5ac0e2721c8f4969b39f79749362aa6f81e1af634adc8c035126675212ecadb5"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7606,33 +7606,32 @@ files = [
 
 [[package]]
 name = "sic-classification-library"
-version = "0.1.3"
+version = "0.1.5"
 description = "Standard Industrial Classification library"
 optional = false
 python-versions = "^3.12"
 groups = ["main"]
 files = []
-develop = false
+develop = true
 
 [package.dependencies]
+openpyxl = "^3.1.5"
 pandas = "^2.3.0"
 pydantic = "^2.11.7"
 
 [package.source]
-type = "git"
-url = "https://github.com/ONSdigital/sic-classification-library.git"
-reference = "v0.1.4"
-resolved_reference = "2f2592dfc501ea48ee1fb0a9a452bbea2e3642c1"
+type = "directory"
+url = "../sic-classification-library"
 
 [[package]]
 name = "sic-classification-utils"
-version = "0.1.13"
+version = "0.1.14"
 description = "Utility functions used for SIC classification"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = []
-develop = false
+develop = true
 
 [package.dependencies]
 autocorrect = "^2.6.1"
@@ -7648,14 +7647,12 @@ pandas = "^2.3.0"
 pydantic = "^2.11.1"
 scikit-learn = "^1.3.0"
 scipy = "^1.15.0"
-sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.4"}
+sic-classification-library = {path = "../sic-classification-library", develop = true}
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.8"}
 
 [package.source]
-type = "git"
-url = "https://github.com/ONSdigital/sic-classification-utils.git"
-reference = "v0.1.13"
-resolved_reference = "0de9621707484fd29e996d7c8dbb43fe4a9b8183"
+type = "directory"
+url = "../sic-classification-utils"
 
 [[package]]
 name = "six"
@@ -9118,4 +9115,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "c10fc9cb4529a40bcbfe3f5e9e7300ce7a7483ea76cab589a4c5bef491e1f5b7"
+content-hash = "2eb173a03e6cff6e4bd3786454a127ddea23dcd7798e5775f1733312947a6b9e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7606,32 +7606,33 @@ files = [
 
 [[package]]
 name = "sic-classification-library"
-version = "0.1.5"
+version = "0.1.3"
 description = "Standard Industrial Classification library"
 optional = false
 python-versions = "^3.12"
 groups = ["main"]
 files = []
-develop = true
+develop = false
 
 [package.dependencies]
-openpyxl = "^3.1.5"
 pandas = "^2.3.0"
 pydantic = "^2.11.7"
 
 [package.source]
-type = "directory"
-url = "../sic-classification-library"
+type = "git"
+url = "https://github.com/ONSdigital/sic-classification-library.git"
+reference = "v0.1.4"
+resolved_reference = "2f2592dfc501ea48ee1fb0a9a452bbea2e3642c1"
 
 [[package]]
 name = "sic-classification-utils"
-version = "0.1.14"
+version = "0.1.13"
 description = "Utility functions used for SIC classification"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = []
-develop = true
+develop = false
 
 [package.dependencies]
 autocorrect = "^2.6.1"
@@ -7647,12 +7648,14 @@ pandas = "^2.3.0"
 pydantic = "^2.11.1"
 scikit-learn = "^1.3.0"
 scipy = "^1.15.0"
-sic-classification-library = {path = "../sic-classification-library", develop = true}
+sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.4"}
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.8"}
 
 [package.source]
-type = "directory"
-url = "../sic-classification-utils"
+type = "git"
+url = "https://github.com/ONSdigital/sic-classification-utils.git"
+reference = "v0.1.13"
+resolved_reference = "0de9621707484fd29e996d7c8dbb43fe4a9b8183"
 
 [[package]]
 name = "six"
@@ -9115,4 +9118,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "2eb173a03e6cff6e4bd3786454a127ddea23dcd7798e5775f1733312947a6b9e"
+content-hash = "c10fc9cb4529a40bcbfe3f5e9e7300ce7a7483ea76cab589a4c5bef491e1f5b7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ pandas = "^2.1.4"
 google-cloud-logging = "^3.9.0"
 google-auth = "^2.28.0"
 fastapi_swagger2 = "^0.2.4"
-sic-classification-library = {path = "../sic-classification-library", develop = true}
-sic-classification-utils = {path = "../sic-classification-utils", develop = true}
+sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.5"}
+sic-classification-utils = {git = "https://github.com/ONSdigital/sic-classification-utils.git", tag = "v0.1.14"}
 soc-classification-library = {git = "https://github.com/ONSdigital/soc-classification-library.git", tag = "v0.1.5"}
 soc-classification-utils = {git = "https://github.com/ONSdigital/soc-classification-utils.git", tag = "v0.1.4"}
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.8"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ pandas = "^2.1.4"
 google-cloud-logging = "^3.9.0"
 google-auth = "^2.28.0"
 fastapi_swagger2 = "^0.2.4"
-sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.4"}
-sic-classification-utils = {git = "https://github.com/ONSdigital/sic-classification-utils.git", tag = "v0.1.13"}
+sic-classification-library = {path = "../sic-classification-library", develop = true}
+sic-classification-utils = {path = "../sic-classification-utils", develop = true}
 soc-classification-library = {git = "https://github.com/ONSdigital/soc-classification-library.git", tag = "v0.1.5"}
 soc-classification-utils = {git = "https://github.com/ONSdigital/soc-classification-utils.git", tag = "v0.1.4"}
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.8"}


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

Dependency-only follow-up for SA-653: refreshes `poetry.lock` so Survey Assist API resolves `sic-classification-library` **v0.1.5** and `sic-classification-utils` **v0.1.14** (SIC data access moved into the library). 

**Depends on:**

1. `sic-classification-library` **v0.1.5** merged and tagged.
2. `sic-classification-utils` **v0.1.14** merged and tagged.

> **CI note:** CI purposefully fails here as until those tags exist, `pyproject.toml` uses editable paths for local SA-653 work:

> ```toml
> sic-classification-library = { path = "../sic-classification-library", develop = true }
> sic-classification-utils = { path = "../sic-classification-utils", develop = true }
> ```

## 📜 Changes Introduced

- [ ] Feature implementation (feat:) / bug fix (fix:) / refactoring (chore:) / documentation (docs:) / testing (test:)
- [ ] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable) — N/A

- [x] Dependency / lockfile only (chore:)
- `pyproject.toml`: pin SIC library **v0.1.5** and SIC utils **v0.1.14** (remove temporary path deps when tagging).
- `poetry.lock`: refreshed.

**No changes** to `api/routes/v1/classify.py`, lookup clients, or public API fields.

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed — N/A

## 🔍 How to Test

### Unit tests (this repo only)

```bash
cd survey-assist-api
poetry install
poetry run pytest tests/test_sic_lookup_client.py -q
```

**Verified:** `16 passed`

SIC classify regression (optional, needs Gemini / vector store as per your usual setup):

```bash
poetry run pytest tests/test_classify.py -k sic -q
```

### Notes
- SIC classify should not fail with missing `sic_data_access` in utils; loaders live in the library.
- If classify errors mention `industrial_classification.data_access`, run `poetry install` and restart the API.

