### PR TITLE
SA-741/instantiate sic soc vector store clients once

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -115,7 +115,14 @@ async def lifespan(fastapi_app: FastAPI):
     else:
         fastapi_app.state.soc_rephrase_client = SOCRephraseClient()
 
-    shared_http_client = httpx.AsyncClient()
+    shared_http_client = httpx.AsyncClient(
+        timeout=httpx.Timeout(5.0, connect=5.0),
+        limits=httpx.Limits(
+            max_connections=100,
+            max_keepalive_connections=20,
+            keepalive_expiry=5.0,
+        ),
+    )
     fastapi_app.state.vector_store_http_client = shared_http_client
     fastapi_app.state.sic_vector_store_client = SICVectorStoreClient(
         base_url=resolve_sic_vector_store_base_url(),
@@ -125,10 +132,33 @@ async def lifespan(fastapi_app: FastAPI):
         base_url=resolve_soc_vector_store_base_url(),
         http_client=shared_http_client,
     )
+    logger.info(
+        "Application clients initialised",
+        sic_llm=type(fastapi_app.state.gemini_llm).__name__,
+        sic_llm_model=fastapi_app.state.gemini_llm.model_name,
+        soc_llm=type(fastapi_app.state.soc_llm).__name__,
+        soc_llm_model=fastapi_app.state.soc_llm.model_name,
+        sic_lookup_client=type(fastapi_app.state.sic_lookup_client).__name__,
+        soc_lookup_client=type(fastapi_app.state.soc_lookup_client).__name__,
+        sic_rephrase_client=type(fastapi_app.state.sic_rephrase_client).__name__,
+        soc_rephrase_client=type(fastapi_app.state.soc_rephrase_client).__name__,
+        sic_vector_store_client=type(
+            fastapi_app.state.sic_vector_store_client
+        ).__name__,
+        soc_vector_store_client=type(
+            fastapi_app.state.soc_vector_store_client
+        ).__name__,
+        http_client=type(shared_http_client).__name__,
+        vector_store_http_client_shared=str(
+            fastapi_app.state.sic_vector_store_client.http_client
+            is fastapi_app.state.soc_vector_store_client.http_client
+        ),
+    )
 
-    yield
-    # Shutdown
-    await shared_http_client.aclose()
+    try:
+        yield
+    finally:
+        await shared_http_client.aclose()
 
 
 app: FastAPI = FastAPI(

--- a/api/main.py
+++ b/api/main.py
@@ -7,12 +7,14 @@ It defines the FastAPI application and the API endpoints.
 import os
 from contextlib import asynccontextmanager
 
+import httpx
 from fastapi import FastAPI
 from fastapi_swagger2 import FastAPISwagger2
 from industrial_classification_utils.llm.llm import ClassificationLLM
 from occupational_classification_utils.llm.llm import (
     ClassificationLLM as SOCClassificationLLM,
 )
+from survey_assist_utils.logging import get_logger
 
 from api.routes.v1.classify import router as classify_router
 from api.routes.v1.config import router as config_router
@@ -24,8 +26,41 @@ from api.routes.v1.soc_lookup import router as soc_lookup_router
 from api.services.firestore_client import init_firestore_client
 from api.services.sic_lookup_client import SICLookupClient
 from api.services.sic_rephrase_client import SICRephraseClient
+from api.services.sic_vector_store_client import SICVectorStoreClient
 from api.services.soc_lookup_client import SOCLookupClient
 from api.services.soc_rephrase_client import SOCRephraseClient
+from api.services.soc_vector_store_client import SOCVectorStoreClient
+
+logger = get_logger(__name__)
+
+DEFAULT_SIC_VECTOR_STORE_URL = "http://localhost:8088"
+DEFAULT_SOC_VECTOR_STORE_URL = "http://localhost:8089"
+
+
+def resolve_sic_vector_store_base_url() -> str:
+    """Resolve the SIC vector store base URL from environment or default."""
+    env_url = os.getenv("SIC_VECTOR_STORE")
+    if env_url and env_url.strip():
+        logger.info(f"Using SIC vector store URL from environment: {env_url.strip()}")
+        return env_url.strip()
+
+    logger.warning(
+        "SIC_VECTOR_STORE environment variable not set, using default localhost URL"
+    )
+    return DEFAULT_SIC_VECTOR_STORE_URL
+
+
+def resolve_soc_vector_store_base_url() -> str:
+    """Resolve the SOC vector store base URL from environment or default."""
+    env_url = os.getenv("SOC_VECTOR_STORE")
+    if env_url and env_url.strip():
+        logger.info(f"Using SOC vector store URL from environment: {env_url.strip()}")
+        return env_url.strip()
+
+    logger.warning(
+        "SOC_VECTOR_STORE environment variable not set, using default localhost URL"
+    )
+    return DEFAULT_SOC_VECTOR_STORE_URL
 
 
 @asynccontextmanager
@@ -80,9 +115,20 @@ async def lifespan(fastapi_app: FastAPI):
     else:
         fastapi_app.state.soc_rephrase_client = SOCRephraseClient()
 
+    shared_http_client = httpx.AsyncClient()
+    fastapi_app.state.vector_store_http_client = shared_http_client
+    fastapi_app.state.sic_vector_store_client = SICVectorStoreClient(
+        base_url=resolve_sic_vector_store_base_url(),
+        http_client=shared_http_client,
+    )
+    fastapi_app.state.soc_vector_store_client = SOCVectorStoreClient(
+        base_url=resolve_soc_vector_store_base_url(),
+        http_client=shared_http_client,
+    )
+
     yield
     # Shutdown
-    # Add any cleanup code here if needed
+    await shared_http_client.aclose()
 
 
 app: FastAPI = FastAPI(

--- a/api/routes/v1/classify.py
+++ b/api/routes/v1/classify.py
@@ -5,7 +5,6 @@ It defines the classification endpoint and returns classification results using
 vector store and LLM.
 """
 
-import os
 import time
 from dataclasses import dataclass
 from typing import Any, Literal, Optional, Union
@@ -35,38 +34,28 @@ logger = get_logger(__name__)
 MAX_LEN = 12
 
 
-def get_sic_vector_store_client() -> SICVectorStoreClient:
-    """Get a SIC vector store client instance.
+def get_sic_vector_store_client(request: Request) -> SICVectorStoreClient:
+    """Get the SIC vector store client from app state.
+
+    Args:
+        request: The FastAPI request object containing the app state.
 
     Returns:
-        SICVectorStoreClient: A SIC vector store client instance.
+        SICVectorStoreClient: The SIC vector store client instance.
     """
-    env_url = os.getenv("SIC_VECTOR_STORE")
-    if env_url and env_url.strip():
-        logger.info(f"Using SIC vector store URL from environment: {env_url}")
-        return SICVectorStoreClient(base_url=env_url.strip())
-
-    logger.warning(
-        "SIC_VECTOR_STORE environment variable not set, using default localhost URL"
-    )
-    return SICVectorStoreClient()
+    return request.app.state.sic_vector_store_client
 
 
-def get_soc_vector_store_client() -> SOCVectorStoreClient:
-    """Get a SOC vector store client instance.
+def get_soc_vector_store_client(request: Request) -> SOCVectorStoreClient:
+    """Get the SOC vector store client from app state.
+
+    Args:
+        request: The FastAPI request object containing the app state.
 
     Returns:
-        SOCVectorStoreClient: A SOC vector store client instance.
+        SOCVectorStoreClient: The SOC vector store client instance.
     """
-    env_url = os.getenv("SOC_VECTOR_STORE")
-    if env_url and env_url.strip():
-        logger.info(f"Using SOC vector store URL from environment: {env_url}")
-        return SOCVectorStoreClient(base_url=env_url.strip())
-
-    logger.warning(
-        "SOC_VECTOR_STORE environment variable not set, using default localhost URL"
-    )
-    return SOCVectorStoreClient()
+    return request.app.state.soc_vector_store_client
 
 
 def get_rephrase_client(request: Request) -> SICRephraseClient:

--- a/api/routes/v1/config.py
+++ b/api/routes/v1/config.py
@@ -32,17 +32,16 @@ def _is_valid_prompt(value: Any) -> bool:
     return isinstance(value, str) and bool(value)
 
 
-def get_vector_store_client() -> SICVectorStoreClient:
-    """Get a vector store client instance.
+def get_vector_store_client(request: Request) -> SICVectorStoreClient:
+    """Get the SIC vector store client from app state.
+
+    Args:
+        request: The FastAPI request object containing the app state.
 
     Returns:
-        SICVectorStoreClient: A vector store client instance.
+        SICVectorStoreClient: The SIC vector store client instance.
     """
-    base_url = "http://localhost:8088"
-    env_url = os.getenv("SIC_VECTOR_STORE")
-    if env_url and env_url.strip():
-        base_url = env_url.strip()
-    return SICVectorStoreClient(base_url=base_url)
+    return request.app.state.sic_vector_store_client
 
 
 vector_store_client_dependency = Depends(get_vector_store_client)

--- a/api/routes/v1/config.py
+++ b/api/routes/v1/config.py
@@ -4,7 +4,6 @@ This module contains the configuration endpoint for the Survey Assist API.
 It defines the configuration endpoint and returns the current configuration settings.
 """
 
-import os
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request

--- a/api/routes/v1/embeddings.py
+++ b/api/routes/v1/embeddings.py
@@ -4,11 +4,10 @@ This module contains the embeddings endpoint for the Survey Assist API.
 It defines the endpoint for checking the status of the embeddings in the vector store.
 """
 
-import os
 import time
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from survey_assist_utils.logging import get_logger
 
 from api.models.embeddings import EMBEDDINGS_STATUS_EXAMPLE, EmbeddingStatus
@@ -22,24 +21,16 @@ EMBEDDINGS_STATUS_UNAVAILABLE_EXAMPLE = {
 }
 
 
-def get_vector_store_client() -> SICVectorStoreClient:
-    """Get a vector store client instance.
+def get_vector_store_client(request: Request) -> SICVectorStoreClient:
+    """Get the SIC vector store client from app state.
+
+    Args:
+        request: The FastAPI request object containing the app state.
 
     Returns:
-        SICVectorStoreClient: A vector store client instance.
+        SICVectorStoreClient: The SIC vector store client instance.
     """
-    # Default to local development URL
-    base_url = "http://localhost:8088"
-
-    # Only use environment variable if it's set and not empty
-    env_url = os.getenv("SIC_VECTOR_STORE")
-    if env_url and env_url.strip():
-        base_url = env_url.strip()
-        logger.debug(f"Using vector store URL from environment: {base_url}")
-    else:
-        logger.debug("Using default vector store URL: http://localhost:8088")
-
-    return SICVectorStoreClient(base_url=base_url)
+    return request.app.state.sic_vector_store_client
 
 
 @router.get(

--- a/api/services/base_vector_store_client.py
+++ b/api/services/base_vector_store_client.py
@@ -37,13 +37,15 @@ class BaseVectorStoreClient(ABC):  # pylint: disable=too-few-public-methods
         base_url: The base URL of the vector store service.
     """
 
-    def __init__(self, base_url: str) -> None:
+    def __init__(self, base_url: str, http_client: httpx.AsyncClient) -> None:
         """Initialise the base vector store client.
 
         Args:
             base_url: The base URL of the vector store service.
+            http_client: Shared async HTTP client for outbound requests.
         """
         self.base_url = base_url
+        self._http_client = http_client
 
     def _get_auth_headers(self) -> dict[str, str]:
         """Get authentication headers for Google Cloud services.
@@ -132,26 +134,25 @@ class BaseVectorStoreClient(ABC):  # pylint: disable=too-few-public-methods
                 f"Vector store request sent - {self.get_service_name()} status",
                 url=url,
             )
-            async with httpx.AsyncClient() as client:
-                response = await client.get(url, headers=headers)
-                duration_ms = int((time.perf_counter() - start_time) * 1000)
-                logger.info(
-                    f"Vector store response received - {self.get_service_name()} status",
-                    status_code=str(response.status_code),
-                    duration_ms=str(duration_ms),
-                )
-                response.raise_for_status()
-                result = response.json()
-                # Log only summary information, not full payloads
-                summary: dict[str, Any] = (
-                    {"keys": list(result.keys())[:5]}
-                    if isinstance(result, dict)
-                    else {"type": type(result).__name__}
-                )
-                logger.debug(
-                    f"{self.get_service_name()} status summary", summary=str(summary)
-                )
-                return result
+            response = await self._http_client.get(url, headers=headers)
+            duration_ms = int((time.perf_counter() - start_time) * 1000)
+            logger.info(
+                f"Vector store response received - {self.get_service_name()} status",
+                status_code=str(response.status_code),
+                duration_ms=str(duration_ms),
+            )
+            response.raise_for_status()
+            result = response.json()
+            # Log only summary information, not full payloads
+            summary: dict[str, Any] = (
+                {"keys": list(result.keys())[:5]}
+                if isinstance(result, dict)
+                else {"type": type(result).__name__}
+            )
+            logger.debug(
+                f"{self.get_service_name()} status summary", summary=str(summary)
+            )
+            return result
         except httpx.HTTPError as e:
             logger.error(
                 f"Failed to check {self.get_service_name()} status", error=str(e)
@@ -212,64 +213,63 @@ class BaseVectorStoreClient(ABC):  # pylint: disable=too-few-public-methods
                 org_description=truncate_identifier(industry_descr),
                 correlation_id=correlation_id,
             )
-            async with httpx.AsyncClient() as client:
-                response = await client.post(
-                    url,
-                    json={
-                        "industry_descr": industry_descr or "",
-                        "job_title": job_title,
-                        "job_description": job_description,
-                    },
-                    headers=headers,
-                )
-                duration_ms = int((time.perf_counter() - start_time) * 1000)
+            response = await self._http_client.post(
+                url,
+                json={
+                    "industry_descr": industry_descr or "",
+                    "job_title": job_title,
+                    "job_description": job_description,
+                },
+                headers=headers,
+            )
+            duration_ms = int((time.perf_counter() - start_time) * 1000)
+            logger.info(
+                f"Vector store response received - {self.get_service_name()} search",
+                status_code=str(response.status_code),
+                duration_ms=str(duration_ms),
+                job_title=truncate_identifier(job_title),
+                job_description=truncate_identifier(job_description),
+                org_description=truncate_identifier(industry_descr),
+                correlation_id=correlation_id,
+            )
+            response.raise_for_status()
+            result = response.json()
+            # Log only counts/summaries, not full payloads
+            if (
+                isinstance(result, dict)
+                and "results" in result
+                and isinstance(result["results"], list)
+            ):
                 logger.info(
-                    f"Vector store response received - {self.get_service_name()} search",
-                    status_code=str(response.status_code),
-                    duration_ms=str(duration_ms),
+                    f"{self.get_service_name()} search results summary",
+                    results_count=str(len(result["results"])),
                     job_title=truncate_identifier(job_title),
                     job_description=truncate_identifier(job_description),
                     org_description=truncate_identifier(industry_descr),
                     correlation_id=correlation_id,
                 )
-                response.raise_for_status()
-                result = response.json()
-                # Log only counts/summaries, not full payloads
-                if (
-                    isinstance(result, dict)
-                    and "results" in result
-                    and isinstance(result["results"], list)
-                ):
-                    logger.info(
-                        f"{self.get_service_name()} search results summary",
-                        results_count=str(len(result["results"])),
-                        job_title=truncate_identifier(job_title),
-                        job_description=truncate_identifier(job_description),
-                        org_description=truncate_identifier(industry_descr),
-                        correlation_id=correlation_id,
-                    )
-                elif isinstance(result, list):
-                    logger.info(
-                        f"{self.get_service_name()} search results summary",
-                        results_count=str(len(result)),
-                        job_title=truncate_identifier(job_title),
-                        job_description=truncate_identifier(job_description),
-                        org_description=truncate_identifier(industry_descr),
-                        correlation_id=correlation_id,
-                    )
-                else:
-                    logger.warning(
-                        f"{self.get_service_name()} search results type",
-                        type=str(type(result).__name__),
-                        job_title=truncate_identifier(job_title),
-                        job_description=truncate_identifier(job_description),
-                        org_description=truncate_identifier(industry_descr),
-                        correlation_id=correlation_id,
-                    )
-                # Handle different response formats
-                if isinstance(result, dict) and "results" in result:
-                    return result["results"]
-                return result
+            elif isinstance(result, list):
+                logger.info(
+                    f"{self.get_service_name()} search results summary",
+                    results_count=str(len(result)),
+                    job_title=truncate_identifier(job_title),
+                    job_description=truncate_identifier(job_description),
+                    org_description=truncate_identifier(industry_descr),
+                    correlation_id=correlation_id,
+                )
+            else:
+                logger.warning(
+                    f"{self.get_service_name()} search results type",
+                    type=str(type(result).__name__),
+                    job_title=truncate_identifier(job_title),
+                    job_description=truncate_identifier(job_description),
+                    org_description=truncate_identifier(industry_descr),
+                    correlation_id=correlation_id,
+                )
+            # Handle different response formats
+            if isinstance(result, dict) and "results" in result:
+                return result["results"]
+            return result
         except httpx.HTTPError as e:
             logger.error(
                 f"Failed to search {self.get_service_name()}",

--- a/api/services/base_vector_store_client.py
+++ b/api/services/base_vector_store_client.py
@@ -47,6 +47,11 @@ class BaseVectorStoreClient(ABC):  # pylint: disable=too-few-public-methods
         self.base_url = base_url
         self._http_client = http_client
 
+    @property
+    def http_client(self) -> httpx.AsyncClient:
+        """Return the shared async HTTP client used for outbound requests."""
+        return self._http_client
+
     def _get_auth_headers(self) -> dict[str, str]:
         """Get authentication headers for Google Cloud services.
 

--- a/api/services/sic_vector_store_client.py
+++ b/api/services/sic_vector_store_client.py
@@ -4,6 +4,8 @@ This module provides a client for the SIC vector store service, which is used to
 check the status of the SIC embeddings and perform similarity searches.
 """
 
+import httpx
+
 from api.services.base_vector_store_client import BaseVectorStoreClient
 
 
@@ -19,13 +21,19 @@ class SICVectorStoreClient(
         base_url: The base URL of the SIC vector store service.
     """
 
-    def __init__(self, base_url: str = "http://localhost:8088") -> None:
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8088",
+        *,
+        http_client: httpx.AsyncClient,
+    ) -> None:
         """Initialise the SIC vector store client.
 
         Args:
             base_url: The base URL of the SIC vector store service.
+            http_client: Shared async HTTP client for outbound requests.
         """
-        super().__init__(base_url)
+        super().__init__(base_url, http_client=http_client)
 
     def get_status_url(self) -> str:
         """Get the SIC vector store status endpoint URL.

--- a/api/services/soc_vector_store_client.py
+++ b/api/services/soc_vector_store_client.py
@@ -4,6 +4,8 @@ This module provides a client for the SOC vector store service, which is used to
 check the status of the SOC embeddings and perform similarity searches.
 """
 
+import httpx
+
 from api.services.base_vector_store_client import BaseVectorStoreClient
 
 
@@ -19,13 +21,19 @@ class SOCVectorStoreClient(
         base_url: The base URL of the SOC vector store service.
     """
 
-    def __init__(self, base_url: str = "http://localhost:8089") -> None:
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8089",
+        *,
+        http_client: httpx.AsyncClient,
+    ) -> None:
         """Initialise the SOC vector store client.
 
         Args:
             base_url: The base URL of the SOC vector store service.
+            http_client: Shared async HTTP client for outbound requests.
         """
-        super().__init__(base_url)
+        super().__init__(base_url, http_client=http_client)
 
     def get_status_url(self) -> str:
         """Get the SOC vector store status endpoint URL.

--- a/poetry.lock
+++ b/poetry.lock
@@ -7627,7 +7627,7 @@ resolved_reference = "92fb9a7a50d6b46cea0ed06fc0fd3082c8677828"
 
 [[package]]
 name = "sic-classification-utils"
-version = "0.1.14"
+version = "0.1.15"
 description = "Utility functions used for SIC classification"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -7655,8 +7655,8 @@ survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.
 [package.source]
 type = "git"
 url = "https://github.com/ONSdigital/sic-classification-utils.git"
-reference = "v0.1.14"
-resolved_reference = "7f8303fac666976440c3bea93f2203f029c5c148"
+reference = "v0.1.15"
+resolved_reference = "65e068dab062ddf8eda14e1cfa679c80f28cf60a"
 
 [[package]]
 name = "six"
@@ -9119,4 +9119,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "5ac0e2721c8f4969b39f79749362aa6f81e1af634adc8c035126675212ecadb5"
+content-hash = "960a0ab5fff2c66af03acc19f0632755f1db2a5fc138b9b5d2dea8106ef0f087"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ google-cloud-logging = "^3.9.0"
 google-auth = "^2.28.0"
 fastapi_swagger2 = "^0.2.4"
 sic-classification-library = {git = "https://github.com/ONSdigital/sic-classification-library.git", tag = "v0.1.5"}
-sic-classification-utils = {git = "https://github.com/ONSdigital/sic-classification-utils.git", tag = "v0.1.14"}
+sic-classification-utils = {git = "https://github.com/ONSdigital/sic-classification-utils.git", tag = "v0.1.15"}
 soc-classification-library = {git = "https://github.com/ONSdigital/soc-classification-library.git", tag = "v0.1.5"}
 soc-classification-utils = {git = "https://github.com/ONSdigital/soc-classification-utils.git", tag = "v0.1.4"}
 survey-assist-utils = {git = "https://github.com/ONSdigital/survey-assist-utils.git", tag = "v0.0.8"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ Functions:
     pytest_sessionfinish(session, exitstatus): Logs the end of a test session.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -20,10 +20,13 @@ from occupational_classification_utils.llm.llm import (
 from survey_assist_utils.logging import get_logger
 
 from api.main import app
+from api.models.embeddings import EMBEDDINGS_STATUS_EXAMPLE
 from api.services.sic_lookup_client import SICLookupClient
 from api.services.sic_rephrase_client import SICRephraseClient
+from api.services.sic_vector_store_client import SICVectorStoreClient
 from api.services.soc_lookup_client import SOCLookupClient
 from api.services.soc_rephrase_client import SOCRephraseClient
+from api.services.soc_vector_store_client import SOCVectorStoreClient
 
 # Configure a global logger
 logger = get_logger(__name__)
@@ -58,6 +61,18 @@ def pytest_configure(config):  # pylint: disable=unused-argument
 
     mock_soc_rephrase_client = MagicMock(spec=SOCRephraseClient)
 
+    mock_sic_vector_store_client = MagicMock(spec=SICVectorStoreClient)
+    mock_sic_vector_store_client.search = AsyncMock(return_value=[])
+    mock_sic_vector_store_client.get_status = AsyncMock(
+        return_value=EMBEDDINGS_STATUS_EXAMPLE
+    )
+
+    mock_soc_vector_store_client = MagicMock(spec=SOCVectorStoreClient)
+    mock_soc_vector_store_client.search = AsyncMock(return_value=[])
+    mock_soc_vector_store_client.get_status = AsyncMock(
+        return_value=EMBEDDINGS_STATUS_EXAMPLE
+    )
+
     # Mock SOC LLM on app state (classify tests patch unambiguous_soc_code inline).
     mock_soc_llm = MagicMock(spec=SOCClassificationLLM)
     mock_soc_llm.model_name = "gemini-2.5-flash"
@@ -69,6 +84,8 @@ def pytest_configure(config):  # pylint: disable=unused-argument
     app.state.soc_lookup_client = mock_soc_lookup_client
     app.state.sic_rephrase_client = mock_sic_rephrase_client
     app.state.soc_rephrase_client = mock_soc_rephrase_client
+    app.state.sic_vector_store_client = mock_sic_vector_store_client
+    app.state.soc_vector_store_client = mock_soc_vector_store_client
 
     logger.info("Global Test Configuration Applied")
 

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -235,13 +235,15 @@ def test_classify_followup_question(  # pylint: disable=too-many-locals
         - All candidates from alt_candidates are passed to formulate_open_question.
     """
     mock_auth.return_value = (MagicMock(), "test-project")
-    _mock_sic_vector_store_search([
+    _mock_sic_vector_store_search(
+        [
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
 
     # Mock the rephrase client
     mock_rephrase_instance = MagicMock()
@@ -340,18 +342,18 @@ def test_classify_followup_question(  # pylint: disable=too-many-locals
 
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
-def test_sic_unambiguous_llm_failure_returns_422(
-    mock_auth, mock_llm
-):
+def test_sic_unambiguous_llm_failure_returns_422(mock_auth, mock_llm):
     """Step 1 LLM failure returns 422 with unambiguous error details."""
     mock_auth.return_value = (MagicMock(), "test-project")
-    _mock_sic_vector_store_search([
+    _mock_sic_vector_store_search(
+        [
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
     mock_llm.unambiguous_sic_code = AsyncMock(side_effect=_LLM_STEP_ERROR)
     response = client.post(
         "/v1/survey-assist/classify",
@@ -369,18 +371,18 @@ def test_sic_unambiguous_llm_failure_returns_422(
 
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
-def test_sic_formulate_open_question_llm_failure_returns_422(
-    mock_auth, mock_llm
-):
+def test_sic_formulate_open_question_llm_failure_returns_422(mock_auth, mock_llm):
     """Step 2 LLM failure returns 422 with open question error details."""
     mock_auth.return_value = (MagicMock(), "test-project")
-    _mock_sic_vector_store_search([
+    _mock_sic_vector_store_search(
+        [
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
     mock_llm.unambiguous_sic_code = AsyncMock(
         return_value=(_mock_not_codable_unambiguous(), None)
     )
@@ -401,7 +403,8 @@ def test_sic_formulate_open_question_llm_failure_returns_422(
 @patch("api.main.app.state.gemini_llm")
 def test_sic_unambiguous_returns_final_code(mock_llm):
     """Electrician: unambiguous_sic_code returns classified=true with code 43210."""
-    _mock_sic_vector_store_search([
+    _mock_sic_vector_store_search(
+        [
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
@@ -412,7 +415,8 @@ def test_sic_unambiguous_returns_final_code(mock_llm):
                 "title": "Plumbing installation",
                 "distance": 0.32,
             },
-        ])
+        ]
+    )
     mock_llm.unambiguous_sic_code = AsyncMock(
         return_value=(
             MagicMock(
@@ -507,9 +511,7 @@ def test_sic_empty_vector_store_still_calls_unambiguous(mock_llm):
 @patch("api.main.app.state.gemini_llm")
 @patch("api.main.app.state.sic_rephrase_client")
 @patch("google.auth.default")
-def test_classify_endpoint_success(
-    mock_auth, mock_rephrase_client, mock_llm
-):
+def test_classify_endpoint_success(mock_auth, mock_rephrase_client, mock_llm):
     """Test the structure of a successful classification response.
 
     This test verifies that a successful classification response contains all
@@ -524,13 +526,15 @@ def test_classify_endpoint_success(
         - The candidates list contains the expected structure.
     """
     mock_auth.return_value = (MagicMock(), "test-project")
-    _mock_sic_vector_store_search([
+    _mock_sic_vector_store_search(
+        [
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
 
     # Mock the rephrase client
     mock_rephrase_client.get_rephrased_description.return_value = (
@@ -585,9 +589,7 @@ def test_classify_endpoint_success(
 @patch("api.routes.v1.classify.SICRephraseClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
-def test_classify_endpoint_invalid_json(
-    mock_auth, mock_llm, mock_rephrase_client
-):
+def test_classify_endpoint_invalid_json(mock_auth, mock_llm, mock_rephrase_client):
     """Test the endpoint's handling of invalid JSON input.
 
     This test verifies that the endpoint correctly handles invalid JSON input by:
@@ -598,13 +600,15 @@ def test_classify_endpoint_invalid_json(
         - The response status code is 422.
     """
     mock_auth.return_value = (MagicMock(), "test-project")
-    _mock_sic_vector_store_search([
+    _mock_sic_vector_store_search(
+        [
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
 
     # Mock the rephrase client
     mock_rephrase_instance = MagicMock()
@@ -640,9 +644,7 @@ def test_classify_endpoint_invalid_json(
 @patch("api.routes.v1.classify.SICRephraseClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
-def test_classify_endpoint_invalid_llm(
-    mock_auth, mock_llm, mock_rephrase_client
-):
+def test_classify_endpoint_invalid_llm(mock_auth, mock_llm, mock_rephrase_client):
     """Test the endpoint's handling of invalid LLM model specifications.
 
     This test verifies that the endpoint correctly handles invalid LLM model
@@ -654,13 +656,15 @@ def test_classify_endpoint_invalid_llm(
         - The response status code is 422.
     """
     mock_auth.return_value = (MagicMock(), "test-project")
-    _mock_sic_vector_store_search([
+    _mock_sic_vector_store_search(
+        [
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
 
     # Mock the rephrase client
     mock_rephrase_instance = MagicMock()
@@ -703,9 +707,7 @@ def test_classify_endpoint_invalid_llm(
 @patch("api.routes.v1.classify.SICRephraseClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
-def test_classify_endpoint_invalid_type(
-    mock_auth, mock_llm, mock_rephrase_client
-):
+def test_classify_endpoint_invalid_type(mock_auth, mock_llm, mock_rephrase_client):
     """Test the endpoint's handling of invalid classification types.
 
     This test verifies that the endpoint correctly handles invalid classification
@@ -717,13 +719,15 @@ def test_classify_endpoint_invalid_type(
         - The response status code is 422.
     """
     mock_auth.return_value = (MagicMock(), "test-project")
-    _mock_sic_vector_store_search([
+    _mock_sic_vector_store_search(
+        [
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
 
     # Mock the rephrase client
     mock_rephrase_instance = MagicMock()
@@ -773,7 +777,8 @@ def test_classify_endpoint_rephrasing_enabled(
 ):
     """Test that rephrasing is enabled when explicitly set to True."""
     mock_auth.return_value = (MagicMock(), "test-project")
-    _mock_sic_vector_store_search([
+    _mock_sic_vector_store_search(
+        [
             {
                 "code": "01110",
                 "title": (
@@ -781,7 +786,8 @@ def test_classify_endpoint_rephrasing_enabled(
                 ),
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
 
     # Mock the rephrase client with rephrased descriptions
     mock_rephrase_client.get_rephrased_description.return_value = "Crop growing"
@@ -845,7 +851,8 @@ def test_classify_endpoint_rephrasing_disabled(
 ):
     """Test that rephrasing is disabled when explicitly set to False."""
     mock_auth.return_value = (MagicMock(), "test-project")
-    _mock_sic_vector_store_search([
+    _mock_sic_vector_store_search(
+        [
             {
                 "code": "01110",
                 "title": (
@@ -853,7 +860,8 @@ def test_classify_endpoint_rephrasing_disabled(
                 ),
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
 
     # Mock the rephrase client
     mock_rephrase_instance = MagicMock()
@@ -921,7 +929,8 @@ def test_classify_endpoint_rephrasing_default(
 ):
     """Test that rephrasing defaults to True when no options provided."""
     mock_auth.return_value = (MagicMock(), "test-project")
-    _mock_sic_vector_store_search([
+    _mock_sic_vector_store_search(
+        [
             {
                 "code": "01110",
                 "title": (
@@ -929,7 +938,8 @@ def test_classify_endpoint_rephrasing_default(
                 ),
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
 
     # Mock the rephrase client with rephrased descriptions
     mock_rephrase_client.get_rephrased_description.return_value = "Crop growing"
@@ -1046,13 +1056,15 @@ def test_classify_endpoint_meta_field_exclusion(
     mock_auth.return_value = (MagicMock(), "test-project")
 
     # Mock vector store
-    _mock_sic_vector_store_search([
+    _mock_sic_vector_store_search(
+        [
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
 
     # Mock the rephrase client
     mock_rephrase_instance = MagicMock()
@@ -1134,17 +1146,17 @@ def test_classify_endpoint_meta_field_exclusion(
     side_effect=AssertionError("SOC classify must not use Excel loaders"),
 )
 @patch("api.main.app.state.soc_llm")
-def test_soc_classify_does_not_require_excel(
-    mock_soc_llm, _mock_read_excel
-):
+def test_soc_classify_does_not_require_excel(mock_soc_llm, _mock_read_excel):
     """SOC classify works even when Excel loaders are unavailable."""
-    _mock_soc_vector_store_search([
+    _mock_soc_vector_store_search(
+        [
             {
                 "code": EXPECTED_SOC_CODE,
                 "title": EXPECTED_SOC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
     mock_soc_llm.unambiguous_soc_code = AsyncMock(
         return_value=(
             MagicMock(
@@ -1183,13 +1195,15 @@ def test_soc_classify_does_not_require_excel(
 @patch("api.main.app.state.soc_llm")
 def test_soc_classify_rephrases_by_default(mock_soc_llm):
     """SOC rephrasing defaults on and applies to candidates only (mirrors SIC)."""
-    _mock_soc_vector_store_search([
+    _mock_soc_vector_store_search(
+        [
             {
                 "code": EXPECTED_SOC_CODE,
                 "title": EXPECTED_SOC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
     mock_soc_llm.unambiguous_soc_code = AsyncMock(
         return_value=(
             MagicMock(
@@ -1231,17 +1245,17 @@ def test_soc_classify_rephrases_by_default(mock_soc_llm):
 
 
 @patch("api.main.app.state.soc_llm")
-def test_soc_classify_rephrased_false_keeps_original_descriptions(
-    mock_soc_llm
-):
+def test_soc_classify_rephrased_false_keeps_original_descriptions(mock_soc_llm):
     """SOC rephrasing remains disabled when explicitly set to false."""
-    _mock_soc_vector_store_search([
+    _mock_soc_vector_store_search(
+        [
             {
                 "code": EXPECTED_SOC_CODE,
                 "title": EXPECTED_SOC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
     mock_soc_llm.unambiguous_soc_code = AsyncMock(
         return_value=(
             MagicMock(
@@ -1286,10 +1300,12 @@ def test_soc_classify_rephrased_false_keeps_original_descriptions(
 @patch("api.main.app.state.soc_llm")
 def test_soc_unambiguous_returns_final_code(mock_soc_llm):
     """Farm hand: unambiguous_soc_code returns classified=true with code 9111."""
-    _mock_soc_vector_store_search([
+    _mock_soc_vector_store_search(
+        [
             {"code": "9111", "title": "Farm workers", "distance": 0.05},
             {"code": "5111", "title": "Other", "distance": 0.32},
-        ])
+        ]
+    )
     mock_soc_llm.unambiguous_soc_code = AsyncMock(
         return_value=(
             MagicMock(
@@ -1342,11 +1358,13 @@ def test_soc_not_codable_returns_followup(mock_soc_llm):
     ``formulate_open_question``, not only the first.
     """
     follow = "Still need detail?"
-    _mock_soc_vector_store_search([
+    _mock_soc_vector_store_search(
+        [
             {"code": "9111", "title": "Farm workers", "distance": 0.15},
             {"code": "5111", "title": "Other agricultural", "distance": 0.19},
             {"code": "9112", "title": "Other farm workers", "distance": 0.22},
-        ])
+        ]
+    )
     mock_unambiguous = MagicMock(
         codable=False,
         class_code=None,
@@ -1408,13 +1426,15 @@ def test_soc_not_codable_returns_followup(mock_soc_llm):
 @patch("api.main.app.state.soc_llm")
 def test_soc_unambiguous_llm_failure_returns_422(mock_soc_llm):
     """Step 1 LLM failure returns 422 with unambiguous SOC error details."""
-    _mock_soc_vector_store_search([
+    _mock_soc_vector_store_search(
+        [
             {
                 "code": EXPECTED_SOC_CODE,
                 "title": EXPECTED_SOC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
     mock_soc_llm.unambiguous_soc_code = AsyncMock(side_effect=_LLM_STEP_ERROR)
     response = client.post(
         "/v1/survey-assist/classify",
@@ -1432,17 +1452,17 @@ def test_soc_unambiguous_llm_failure_returns_422(mock_soc_llm):
 
 
 @patch("api.main.app.state.soc_llm")
-def test_soc_formulate_open_question_llm_failure_returns_422(
-    mock_soc_llm
-):
+def test_soc_formulate_open_question_llm_failure_returns_422(mock_soc_llm):
     """Step 2 LLM failure returns 422 with open question error details."""
-    _mock_soc_vector_store_search([
+    _mock_soc_vector_store_search(
+        [
             {
                 "code": EXPECTED_SOC_CODE,
                 "title": EXPECTED_SOC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ])
+        ]
+    )
     mock_soc_llm.unambiguous_soc_code = AsyncMock(
         return_value=(_mock_not_codable_unambiguous(), None)
     )
@@ -1462,9 +1482,7 @@ def test_soc_formulate_open_question_llm_failure_returns_422(
 
 
 @patch("api.main.app.state.soc_llm")
-def test_soc_empty_vector_store_still_calls_unambiguous(
-    mock_soc_llm
-):
+def test_soc_empty_vector_store_still_calls_unambiguous(mock_soc_llm):
     """Empty search results still run two-step flow (mirrors SIC)."""
     _mock_soc_vector_store_search([])
     mock_unambiguous = MagicMock(

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -54,6 +54,16 @@ EXPECTED_COMBINED_RESULTS_COUNT = 2  # SIC + SOC results
 _LLM_STEP_ERROR = RuntimeError("mock llm step failure")
 
 
+def _mock_sic_vector_store_search(return_value):
+    """Configure the app-scoped SIC vector store mock search response."""
+    app.state.sic_vector_store_client.search = AsyncMock(return_value=return_value)
+
+
+def _mock_soc_vector_store_search(return_value):
+    """Configure the app-scoped SOC vector store mock search response."""
+    app.state.soc_vector_store_client.search = AsyncMock(return_value=return_value)
+
+
 def _assert_llm_classification_422(response, expected_details_fragment: str) -> None:
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     error = response.json()["detail"]["error"]
@@ -85,47 +95,40 @@ class TestClassifyEndpoint:
         """Initialise test class attributes."""
         self.mock_auth = None
         self.mock_llm = None
-        self.mock_vector_store = None
         self.mock_vertexai = None
         self.mock_rephrase_client = None
 
     @pytest.fixture(autouse=True)
     def _patch_soc_vector_store(self):
-        """Patch SOC vector store so SOC classify tests get mock search results."""
-        with patch(
-            "api.routes.v1.classify.SOCVectorStoreClient"
-        ) as mock_soc_vector_store:
-            mock_soc_vector_store.return_value.search = AsyncMock(
-                return_value=[
-                    {
-                        "code": EXPECTED_SOC_CODE,
-                        "title": EXPECTED_SOC_DESCRIPTION,
-                        "distance": 0.05,
-                    }
-                ]
-            )
-            yield
+        """Configure SOC vector store mock search results for classify tests."""
+        _mock_soc_vector_store_search(
+            [
+                {
+                    "code": EXPECTED_SOC_CODE,
+                    "title": EXPECTED_SOC_DESCRIPTION,
+                    "distance": 0.05,
+                }
+            ]
+        )
+        yield
 
     @patch("api.routes.v1.classify.SICRephraseClient")
-    @patch("api.routes.v1.classify.SICVectorStoreClient")
     @patch("api.main.app.state.gemini_llm")
     @patch("google.auth.default")
     def setup_method(
         self,
         mock_auth,
         mock_llm,
-        mock_vector_store,
         mock_rephrase_client,
     ):
         """Set up test fixtures."""
         self.mock_auth = mock_auth
         self.mock_llm = mock_llm
-        self.mock_vector_store = mock_vector_store
         self.mock_rephrase_client = mock_rephrase_client
 
         self.mock_auth.return_value = (MagicMock(), "test-project")
-        self.mock_vector_store.return_value.search = AsyncMock(
-            return_value=[
+        _mock_sic_vector_store_search(
+            [
                 {
                     "code": EXPECTED_SIC_CODE,
                     "title": EXPECTED_SIC_DESCRIPTION,
@@ -208,11 +211,10 @@ class TestClassifyEndpoint:
 
 
 @patch("api.routes.v1.classify.SICRephraseClient")
-@patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
 def test_classify_followup_question(  # pylint: disable=too-many-locals
-    mock_auth, mock_llm, mock_vector_store, mock_rephrase_client
+    mock_auth, mock_llm, mock_rephrase_client
 ):
     """Test the follow-up question functionality of the classification endpoint.
 
@@ -233,15 +235,13 @@ def test_classify_followup_question(  # pylint: disable=too-many-locals
         - All candidates from alt_candidates are passed to formulate_open_question.
     """
     mock_auth.return_value = (MagicMock(), "test-project")
-    mock_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_sic_vector_store_search([
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
 
     # Mock the rephrase client
     mock_rephrase_instance = MagicMock()
@@ -338,23 +338,20 @@ def test_classify_followup_question(  # pylint: disable=too-many-locals
     ), f"Expected {expected_candidates_count} candidates to be passed, got {len(llm_output)}"
 
 
-@patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
 def test_sic_unambiguous_llm_failure_returns_422(
-    mock_auth, mock_llm, mock_vector_store
+    mock_auth, mock_llm
 ):
     """Step 1 LLM failure returns 422 with unambiguous error details."""
     mock_auth.return_value = (MagicMock(), "test-project")
-    mock_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_sic_vector_store_search([
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
     mock_llm.unambiguous_sic_code = AsyncMock(side_effect=_LLM_STEP_ERROR)
     response = client.post(
         "/v1/survey-assist/classify",
@@ -370,23 +367,20 @@ def test_sic_unambiguous_llm_failure_returns_422(
     mock_llm.formulate_open_question.assert_not_called()
 
 
-@patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
 def test_sic_formulate_open_question_llm_failure_returns_422(
-    mock_auth, mock_llm, mock_vector_store
+    mock_auth, mock_llm
 ):
     """Step 2 LLM failure returns 422 with open question error details."""
     mock_auth.return_value = (MagicMock(), "test-project")
-    mock_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_sic_vector_store_search([
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
     mock_llm.unambiguous_sic_code = AsyncMock(
         return_value=(_mock_not_codable_unambiguous(), None)
     )
@@ -404,12 +398,10 @@ def test_sic_formulate_open_question_llm_failure_returns_422(
     _assert_llm_classification_422(response, "Open question formulation failed")
 
 
-@patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
-def test_sic_unambiguous_returns_final_code(mock_llm, mock_vector_store):
+def test_sic_unambiguous_returns_final_code(mock_llm):
     """Electrician: unambiguous_sic_code returns classified=true with code 43210."""
-    mock_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_sic_vector_store_search([
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
@@ -420,8 +412,7 @@ def test_sic_unambiguous_returns_final_code(mock_llm, mock_vector_store):
                 "title": "Plumbing installation",
                 "distance": 0.32,
             },
-        ]
-    )
+        ])
     mock_llm.unambiguous_sic_code = AsyncMock(
         return_value=(
             MagicMock(
@@ -468,11 +459,10 @@ def test_sic_unambiguous_returns_final_code(mock_llm, mock_vector_store):
     )
 
 
-@patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
-def test_sic_empty_vector_store_still_calls_unambiguous(mock_llm, mock_vector_store):
+def test_sic_empty_vector_store_still_calls_unambiguous(mock_llm):
     """Empty search results still run two-step flow (mirrors SOC)."""
-    mock_vector_store.return_value.search = AsyncMock(return_value=[])
+    _mock_sic_vector_store_search([])
     mock_unambiguous = MagicMock(
         codable=False,
         class_code=None,
@@ -514,12 +504,11 @@ def test_sic_empty_vector_store_still_calls_unambiguous(mock_llm, mock_vector_st
     mock_llm.formulate_open_question.assert_called_once()
 
 
-@patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("api.main.app.state.sic_rephrase_client")
 @patch("google.auth.default")
 def test_classify_endpoint_success(
-    mock_auth, mock_rephrase_client, mock_llm, mock_vector_store
+    mock_auth, mock_rephrase_client, mock_llm
 ):
     """Test the structure of a successful classification response.
 
@@ -535,15 +524,13 @@ def test_classify_endpoint_success(
         - The candidates list contains the expected structure.
     """
     mock_auth.return_value = (MagicMock(), "test-project")
-    mock_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_sic_vector_store_search([
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
 
     # Mock the rephrase client
     mock_rephrase_client.get_rephrased_description.return_value = (
@@ -596,11 +583,10 @@ def test_classify_endpoint_success(
 
 
 @patch("api.routes.v1.classify.SICRephraseClient")
-@patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
 def test_classify_endpoint_invalid_json(
-    mock_auth, mock_llm, mock_vector_store, mock_rephrase_client
+    mock_auth, mock_llm, mock_rephrase_client
 ):
     """Test the endpoint's handling of invalid JSON input.
 
@@ -612,15 +598,13 @@ def test_classify_endpoint_invalid_json(
         - The response status code is 422.
     """
     mock_auth.return_value = (MagicMock(), "test-project")
-    mock_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_sic_vector_store_search([
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
 
     # Mock the rephrase client
     mock_rephrase_instance = MagicMock()
@@ -654,11 +638,10 @@ def test_classify_endpoint_invalid_json(
 
 
 @patch("api.routes.v1.classify.SICRephraseClient")
-@patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
 def test_classify_endpoint_invalid_llm(
-    mock_auth, mock_llm, mock_vector_store, mock_rephrase_client
+    mock_auth, mock_llm, mock_rephrase_client
 ):
     """Test the endpoint's handling of invalid LLM model specifications.
 
@@ -671,15 +654,13 @@ def test_classify_endpoint_invalid_llm(
         - The response status code is 422.
     """
     mock_auth.return_value = (MagicMock(), "test-project")
-    mock_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_sic_vector_store_search([
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
 
     # Mock the rephrase client
     mock_rephrase_instance = MagicMock()
@@ -720,11 +701,10 @@ def test_classify_endpoint_invalid_llm(
 
 
 @patch("api.routes.v1.classify.SICRephraseClient")
-@patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
 def test_classify_endpoint_invalid_type(
-    mock_auth, mock_llm, mock_vector_store, mock_rephrase_client
+    mock_auth, mock_llm, mock_rephrase_client
 ):
     """Test the endpoint's handling of invalid classification types.
 
@@ -737,15 +717,13 @@ def test_classify_endpoint_invalid_type(
         - The response status code is 422.
     """
     mock_auth.return_value = (MagicMock(), "test-project")
-    mock_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_sic_vector_store_search([
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
 
     # Mock the rephrase client
     mock_rephrase_instance = MagicMock()
@@ -787,17 +765,15 @@ def test_classify_endpoint_invalid_type(
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-@patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("api.main.app.state.sic_rephrase_client")
 @patch("google.auth.default")
 def test_classify_endpoint_rephrasing_enabled(
-    mock_auth, mock_rephrase_client, mock_llm, mock_vector_store
+    mock_auth, mock_rephrase_client, mock_llm
 ):
     """Test that rephrasing is enabled when explicitly set to True."""
     mock_auth.return_value = (MagicMock(), "test-project")
-    mock_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_sic_vector_store_search([
             {
                 "code": "01110",
                 "title": (
@@ -805,8 +781,7 @@ def test_classify_endpoint_rephrasing_enabled(
                 ),
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
 
     # Mock the rephrase client with rephrased descriptions
     mock_rephrase_client.get_rephrased_description.return_value = "Crop growing"
@@ -863,16 +838,14 @@ def test_classify_endpoint_rephrasing_enabled(
 
 
 @patch("api.routes.v1.classify.SICRephraseClient")
-@patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
 def test_classify_endpoint_rephrasing_disabled(
-    mock_auth, mock_llm, mock_vector_store, mock_rephrase_client
+    mock_auth, mock_llm, mock_rephrase_client
 ):
     """Test that rephrasing is disabled when explicitly set to False."""
     mock_auth.return_value = (MagicMock(), "test-project")
-    mock_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_sic_vector_store_search([
             {
                 "code": "01110",
                 "title": (
@@ -880,8 +853,7 @@ def test_classify_endpoint_rephrasing_disabled(
                 ),
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
 
     # Mock the rephrase client
     mock_rephrase_instance = MagicMock()
@@ -941,17 +913,15 @@ def test_classify_endpoint_rephrasing_disabled(
             )
 
 
-@patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("api.main.app.state.sic_rephrase_client")
 @patch("google.auth.default")
 def test_classify_endpoint_rephrasing_default(
-    mock_auth, mock_rephrase_client, mock_llm, mock_vector_store
+    mock_auth, mock_rephrase_client, mock_llm
 ):
     """Test that rephrasing defaults to True when no options provided."""
     mock_auth.return_value = (MagicMock(), "test-project")
-    mock_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_sic_vector_store_search([
             {
                 "code": "01110",
                 "title": (
@@ -959,8 +929,7 @@ def test_classify_endpoint_rephrasing_default(
                 ),
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
 
     # Mock the rephrase client with rephrased descriptions
     mock_rephrase_client.get_rephrased_description.return_value = "Crop growing"
@@ -1016,18 +985,17 @@ def test_classify_endpoint_rephrasing_default(
 
 
 @patch("api.routes.v1.classify.SICRephraseClient")
-@patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
 def test_classify_endpoint_rephrasing_options_validation(
-    mock_auth, mock_llm, mock_vector_store, mock_rephrase_client
+    mock_auth, mock_llm, mock_rephrase_client
 ):
     """Test that invalid options are properly validated."""
     # Mock auth
     mock_auth.return_value = (MagicMock(), "test-project")
 
     # Mock vector store
-    mock_vector_store.return_value.search = AsyncMock(return_value=[])
+    _mock_sic_vector_store_search([])
 
     # Mock rephrase client
     mock_rephrase_instance = MagicMock()
@@ -1068,26 +1036,23 @@ def test_classify_endpoint_rephrasing_options_validation(
 
 
 @patch("api.routes.v1.classify.SICRephraseClient")
-@patch("api.routes.v1.classify.SICVectorStoreClient")
 @patch("api.main.app.state.gemini_llm")
 @patch("google.auth.default")
 def test_classify_endpoint_meta_field_exclusion(
-    mock_auth, mock_llm, mock_vector_store, mock_rephrase_client
+    mock_auth, mock_llm, mock_rephrase_client
 ):
     """Test that the meta field is excluded when options are not provided."""
     # Mock auth
     mock_auth.return_value = (MagicMock(), "test-project")
 
     # Mock vector store
-    mock_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_sic_vector_store_search([
             {
                 "code": EXPECTED_SIC_CODE,
                 "title": EXPECTED_SIC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
 
     # Mock the rephrase client
     mock_rephrase_instance = MagicMock()
@@ -1168,21 +1133,18 @@ def test_classify_endpoint_meta_field_exclusion(
     "occupational_classification.data_access.soc_data_access.pd.read_excel",
     side_effect=AssertionError("SOC classify must not use Excel loaders"),
 )
-@patch("api.routes.v1.classify.SOCVectorStoreClient")
 @patch("api.main.app.state.soc_llm")
 def test_soc_classify_does_not_require_excel(
-    mock_soc_llm, mock_soc_vector_store, _mock_read_excel
+    mock_soc_llm, _mock_read_excel
 ):
     """SOC classify works even when Excel loaders are unavailable."""
-    mock_soc_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_soc_vector_store_search([
             {
                 "code": EXPECTED_SOC_CODE,
                 "title": EXPECTED_SOC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
     mock_soc_llm.unambiguous_soc_code = AsyncMock(
         return_value=(
             MagicMock(
@@ -1218,19 +1180,16 @@ def test_soc_classify_does_not_require_excel(
     assert data["results"][0]["type"] == "soc"
 
 
-@patch("api.routes.v1.classify.SOCVectorStoreClient")
 @patch("api.main.app.state.soc_llm")
-def test_soc_classify_rephrases_by_default(mock_soc_llm, mock_soc_vector_store):
+def test_soc_classify_rephrases_by_default(mock_soc_llm):
     """SOC rephrasing defaults on and applies to candidates only (mirrors SIC)."""
-    mock_soc_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_soc_vector_store_search([
             {
                 "code": EXPECTED_SOC_CODE,
                 "title": EXPECTED_SOC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
     mock_soc_llm.unambiguous_soc_code = AsyncMock(
         return_value=(
             MagicMock(
@@ -1271,21 +1230,18 @@ def test_soc_classify_rephrases_by_default(mock_soc_llm, mock_soc_vector_store):
     assert first["candidates"][0]["descriptive"] == EXPECTED_SOC_DESCRIPTION
 
 
-@patch("api.routes.v1.classify.SOCVectorStoreClient")
 @patch("api.main.app.state.soc_llm")
 def test_soc_classify_rephrased_false_keeps_original_descriptions(
-    mock_soc_llm, mock_soc_vector_store
+    mock_soc_llm
 ):
     """SOC rephrasing remains disabled when explicitly set to false."""
-    mock_soc_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_soc_vector_store_search([
             {
                 "code": EXPECTED_SOC_CODE,
                 "title": EXPECTED_SOC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
     mock_soc_llm.unambiguous_soc_code = AsyncMock(
         return_value=(
             MagicMock(
@@ -1327,16 +1283,13 @@ def test_soc_classify_rephrased_false_keeps_original_descriptions(
     assert first["candidates"][0]["descriptive"] == "Elementary occupations"
 
 
-@patch("api.routes.v1.classify.SOCVectorStoreClient")
 @patch("api.main.app.state.soc_llm")
-def test_soc_unambiguous_returns_final_code(mock_soc_llm, mock_soc_vector_store):
+def test_soc_unambiguous_returns_final_code(mock_soc_llm):
     """Farm hand: unambiguous_soc_code returns classified=true with code 9111."""
-    mock_soc_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_soc_vector_store_search([
             {"code": "9111", "title": "Farm workers", "distance": 0.05},
             {"code": "5111", "title": "Other", "distance": 0.32},
-        ]
-    )
+        ])
     mock_soc_llm.unambiguous_soc_code = AsyncMock(
         return_value=(
             MagicMock(
@@ -1381,22 +1334,19 @@ def test_soc_unambiguous_returns_final_code(mock_soc_llm, mock_soc_vector_store)
     )
 
 
-@patch("api.routes.v1.classify.SOCVectorStoreClient")
 @patch("api.main.app.state.soc_llm")
-def test_soc_not_codable_returns_followup(mock_soc_llm, mock_soc_vector_store):
+def test_soc_not_codable_returns_followup(mock_soc_llm):
     """When unambiguous_soc_code sets codable false, formulate_open_question supplies followup.
 
     Mirrors ``test_classify_followup_question``: all ``alt_candidates`` are passed to
     ``formulate_open_question``, not only the first.
     """
     follow = "Still need detail?"
-    mock_soc_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_soc_vector_store_search([
             {"code": "9111", "title": "Farm workers", "distance": 0.15},
             {"code": "5111", "title": "Other agricultural", "distance": 0.19},
             {"code": "9112", "title": "Other farm workers", "distance": 0.22},
-        ]
-    )
+        ])
     mock_unambiguous = MagicMock(
         codable=False,
         class_code=None,
@@ -1455,19 +1405,16 @@ def test_soc_not_codable_returns_followup(mock_soc_llm, mock_soc_vector_store):
     )
 
 
-@patch("api.routes.v1.classify.SOCVectorStoreClient")
 @patch("api.main.app.state.soc_llm")
-def test_soc_unambiguous_llm_failure_returns_422(mock_soc_llm, mock_soc_vector_store):
+def test_soc_unambiguous_llm_failure_returns_422(mock_soc_llm):
     """Step 1 LLM failure returns 422 with unambiguous SOC error details."""
-    mock_soc_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_soc_vector_store_search([
             {
                 "code": EXPECTED_SOC_CODE,
                 "title": EXPECTED_SOC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
     mock_soc_llm.unambiguous_soc_code = AsyncMock(side_effect=_LLM_STEP_ERROR)
     response = client.post(
         "/v1/survey-assist/classify",
@@ -1484,21 +1431,18 @@ def test_soc_unambiguous_llm_failure_returns_422(mock_soc_llm, mock_soc_vector_s
     mock_soc_llm.formulate_open_question.assert_not_called()
 
 
-@patch("api.routes.v1.classify.SOCVectorStoreClient")
 @patch("api.main.app.state.soc_llm")
 def test_soc_formulate_open_question_llm_failure_returns_422(
-    mock_soc_llm, mock_soc_vector_store
+    mock_soc_llm
 ):
     """Step 2 LLM failure returns 422 with open question error details."""
-    mock_soc_vector_store.return_value.search = AsyncMock(
-        return_value=[
+    _mock_soc_vector_store_search([
             {
                 "code": EXPECTED_SOC_CODE,
                 "title": EXPECTED_SOC_DESCRIPTION,
                 "distance": 0.05,
             }
-        ]
-    )
+        ])
     mock_soc_llm.unambiguous_soc_code = AsyncMock(
         return_value=(_mock_not_codable_unambiguous(), None)
     )
@@ -1517,13 +1461,12 @@ def test_soc_formulate_open_question_llm_failure_returns_422(
     _assert_llm_classification_422(response, "Open question formulation failed")
 
 
-@patch("api.routes.v1.classify.SOCVectorStoreClient")
 @patch("api.main.app.state.soc_llm")
 def test_soc_empty_vector_store_still_calls_unambiguous(
-    mock_soc_llm, mock_soc_vector_store
+    mock_soc_llm
 ):
     """Empty search results still run two-step flow (mirrors SIC)."""
-    mock_soc_vector_store.return_value.search = AsyncMock(return_value=[])
+    _mock_soc_vector_store_search([])
     mock_unambiguous = MagicMock(
         codable=False,
         class_code=None,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,17 +16,21 @@ Dependencies:
 """
 
 from http import HTTPStatus
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
 from fastapi import HTTPException
-from fastapi.testclient import TestClient
 from survey_assist_utils.logging import get_logger
 
-from api.main import app, resolve_sic_vector_store_base_url
+from api.main import (
+    app,
+    resolve_sic_vector_store_base_url,
+    resolve_soc_vector_store_base_url,
+)
 from api.models.embeddings import EMBEDDINGS_STATUS_EXAMPLE
 from api.services.sic_vector_store_client import SICVectorStoreClient
+from api.services.soc_vector_store_client import SOCVectorStoreClient
 
 logger = get_logger(__name__)
 
@@ -52,25 +56,24 @@ def test_resolve_sic_vector_store_base_url_uses_expected_base_url(
 
 
 @pytest.mark.api
-@patch("api.main.init_firestore_client")
-@patch("api.main.SOCClassificationLLM")
-@patch("api.main.ClassificationLLM")
-def test_vector_store_clients_share_http_client(
-    mock_classification_llm,
-    mock_soc_classification_llm,
-    _mock_init_firestore,
-):
-    """Vector store clients are app-scoped and share one HTTP client."""
-    mock_classification_llm.return_value = MagicMock()
-    mock_soc_classification_llm.return_value = MagicMock()
-
-    with TestClient(app) as client:
-        shared_http_client = client.app.state.vector_store_http_client
-        sic_client = client.app.state.sic_vector_store_client
-        soc_client = client.app.state.soc_vector_store_client
+@pytest.mark.asyncio
+async def test_vector_store_clients_share_http_client():
+    """SIC and SOC vector store clients share one injected HTTP client."""
+    shared_http_client = httpx.AsyncClient()
+    try:
+        sic_client = SICVectorStoreClient(
+            base_url=resolve_sic_vector_store_base_url(),
+            http_client=shared_http_client,
+        )
+        soc_client = SOCVectorStoreClient(
+            base_url=resolve_soc_vector_store_base_url(),
+            http_client=shared_http_client,
+        )
 
         assert sic_client.http_client is shared_http_client
         assert soc_client.http_client is shared_http_client
+    finally:
+        await shared_http_client.aclose()
 
 
 @pytest.mark.api

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,6 +26,7 @@ from survey_assist_utils.logging import get_logger
 
 from api.main import app, resolve_sic_vector_store_base_url
 from api.models.embeddings import EMBEDDINGS_STATUS_EXAMPLE
+from api.services.sic_vector_store_client import SICVectorStoreClient
 
 logger = get_logger(__name__)
 
@@ -58,8 +59,8 @@ def test_vector_store_clients_share_http_client():
         sic_client = client.app.state.sic_vector_store_client
         soc_client = client.app.state.soc_vector_store_client
 
-        assert sic_client._http_client is shared_http_client
-        assert soc_client._http_client is shared_http_client
+        assert sic_client.http_client is shared_http_client
+        assert soc_client.http_client is shared_http_client
 
 
 @pytest.mark.api
@@ -146,8 +147,6 @@ async def test_get_status_success():
         "api.services.base_vector_store_client.BaseVectorStoreClient._get_auth_headers",
         return_value={},
     ):
-        from api.services.sic_vector_store_client import SICVectorStoreClient
-
         client = SICVectorStoreClient(
             base_url="http://localhost:8088",
             http_client=mock_http_client,
@@ -178,8 +177,6 @@ async def test_get_status_connection_error():
         "api.services.base_vector_store_client.BaseVectorStoreClient._get_auth_headers",
         return_value={},
     ):
-        from api.services.sic_vector_store_client import SICVectorStoreClient
-
         client = SICVectorStoreClient(
             base_url="http://nonexistent:8088",
             http_client=mock_http_client,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,11 +21,11 @@ from unittest.mock import AsyncMock, Mock, patch
 import httpx
 import pytest
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 from survey_assist_utils.logging import get_logger
 
+from api.main import app, resolve_sic_vector_store_base_url
 from api.models.embeddings import EMBEDDINGS_STATUS_EXAMPLE
-from api.routes.v1.embeddings import get_vector_store_client
-from api.services.sic_vector_store_client import SICVectorStoreClient
 
 logger = get_logger(__name__)
 
@@ -38,18 +38,28 @@ logger = get_logger(__name__)
         (None, "http://localhost:8088"),
     ],
 )
-def test_get_vector_store_client_uses_expected_base_url(
+def test_resolve_sic_vector_store_base_url_uses_expected_base_url(
     monkeypatch, env_value, expected_base_url
 ):
-    """Test vector store client URL resolution from environment and fallback."""
+    """Test SIC vector store URL resolution from environment and fallback."""
     if env_value is None:
         monkeypatch.delenv("SIC_VECTOR_STORE", raising=False)
     else:
         monkeypatch.setenv("SIC_VECTOR_STORE", env_value)
 
-    client = get_vector_store_client()
+    assert resolve_sic_vector_store_base_url() == expected_base_url
 
-    assert client.base_url == expected_base_url
+
+@pytest.mark.api
+def test_vector_store_clients_share_http_client():
+    """Vector store clients are app-scoped and share one HTTP client."""
+    with TestClient(app) as client:
+        shared_http_client = client.app.state.vector_store_http_client
+        sic_client = client.app.state.sic_vector_store_client
+        soc_client = client.app.state.soc_vector_store_client
+
+        assert sic_client._http_client is shared_http_client
+        assert soc_client._http_client is shared_http_client
 
 
 @pytest.mark.api
@@ -127,21 +137,21 @@ async def test_get_status_success():
     """
     mock_response = AsyncMock()
     mock_response.json = Mock(return_value=EMBEDDINGS_STATUS_EXAMPLE)
-    mock_response.raise_for_status = AsyncMock()
+    mock_response.raise_for_status = Mock()
 
-    mock_client = AsyncMock()
-    mock_client.__aenter__.return_value = mock_client
-    mock_client.__aexit__.return_value = None
-    mock_client.get.return_value = mock_response
+    mock_http_client = AsyncMock()
+    mock_http_client.get.return_value = mock_response
 
-    with (
-        patch("httpx.AsyncClient", return_value=mock_client),
-        patch(
-            "api.services.base_vector_store_client.BaseVectorStoreClient._get_auth_headers",
-            return_value={},
-        ),
+    with patch(
+        "api.services.base_vector_store_client.BaseVectorStoreClient._get_auth_headers",
+        return_value={},
     ):
-        client = SICVectorStoreClient(base_url="http://localhost:8088")
+        from api.services.sic_vector_store_client import SICVectorStoreClient
+
+        client = SICVectorStoreClient(
+            base_url="http://localhost:8088",
+            http_client=mock_http_client,
+        )
         response = await client.get_status()
         assert response == EMBEDDINGS_STATUS_EXAMPLE
 
@@ -161,14 +171,19 @@ async def test_get_status_connection_error():
     - The raised exception has the correct status code.
     - The error message contains the expected connection failure text.
     """
-    with (
-        patch("httpx.AsyncClient.get", side_effect=httpx.HTTPError("Connection error")),
-        patch(
-            "api.services.base_vector_store_client.BaseVectorStoreClient._get_auth_headers",
-            return_value={},
-        ),
+    mock_http_client = AsyncMock()
+    mock_http_client.get.side_effect = httpx.HTTPError("Connection error")
+
+    with patch(
+        "api.services.base_vector_store_client.BaseVectorStoreClient._get_auth_headers",
+        return_value={},
     ):
-        client = SICVectorStoreClient(base_url="http://nonexistent:8088")
+        from api.services.sic_vector_store_client import SICVectorStoreClient
+
+        client = SICVectorStoreClient(
+            base_url="http://nonexistent:8088",
+            http_client=mock_http_client,
+        )
         with pytest.raises(HTTPException) as exc_info:
             await client.get_status()
         assert exc_info.value.status_code == HTTPStatus.SERVICE_UNAVAILABLE
@@ -188,10 +203,8 @@ def test_embeddings_endpoint(test_client):
     - The response status code is HTTPStatus.OK.
     - The response JSON matches the expected status dictionary.
     """
-    with patch(
-        "api.services.sic_vector_store_client.SICVectorStoreClient.get_status"
-    ) as mock_get_status:
-        mock_get_status.return_value = EMBEDDINGS_STATUS_EXAMPLE
-        response = test_client.get("/v1/survey-assist/embeddings")
-        assert response.status_code == HTTPStatus.OK
-        assert response.json() == EMBEDDINGS_STATUS_EXAMPLE
+    mock_get_status = AsyncMock(return_value=EMBEDDINGS_STATUS_EXAMPLE)
+    app.state.sic_vector_store_client.get_status = mock_get_status
+    response = test_client.get("/v1/survey-assist/embeddings")
+    assert response.status_code == HTTPStatus.OK
+    assert response.json() == EMBEDDINGS_STATUS_EXAMPLE

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,7 +16,7 @@ Dependencies:
 """
 
 from http import HTTPStatus
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import httpx
 import pytest
@@ -52,8 +52,18 @@ def test_resolve_sic_vector_store_base_url_uses_expected_base_url(
 
 
 @pytest.mark.api
-def test_vector_store_clients_share_http_client():
+@patch("api.main.init_firestore_client")
+@patch("api.main.SOCClassificationLLM")
+@patch("api.main.ClassificationLLM")
+def test_vector_store_clients_share_http_client(
+    mock_classification_llm,
+    mock_soc_classification_llm,
+    _mock_init_firestore,
+):
     """Vector store clients are app-scoped and share one HTTP client."""
+    mock_classification_llm.return_value = MagicMock()
+    mock_soc_classification_llm.return_value = MagicMock()
+
     with TestClient(app) as client:
         shared_http_client = client.app.state.vector_store_http_client
         sic_client = client.app.state.sic_vector_store_client


### PR DESCRIPTION
# 📌 Pull Request

> **Please complete all sections**

## ✨ Summary

Creates `SICVectorStoreClient` and `SOCVectorStoreClient` once when the API starts, and passes the same shared `httpx.AsyncClient` to both. This matches how lookup, rephrase, and LLM clients are already created once at startup. The classify, config, and embeddings routes now take the vector store clients from `request.app.state` instead of creating new clients (and new HTTP connections) on every request.

## 📜 Changes Introduced

- `api/main.py` — create one `httpx.AsyncClient` when the app starts, store `sic_vector_store_client` and `soc_vector_store_client` on `app.state`, and close the shared client when the app shuts down; read `SIC_VECTOR_STORE` and `SOC_VECTOR_STORE` once at startup.
- `api/services/base_vector_store_client.py` — accept an `http_client` in `__init__` and reuse it for `get_status()` and `search()`; add a public `http_client` property for tests.
- `api/services/sic_vector_store_client.py` / `api/services/soc_vector_store_client.py` — require the shared `http_client` argument and pass it to `BaseVectorStoreClient`.
- `api/routes/v1/classify.py` — read SIC and SOC vector store clients from `request.app.state` instead of creating them on each request.
- `api/routes/v1/config.py` / `api/routes/v1/embeddings.py` — read `sic_vector_store_client` from `request.app.state` instead of creating a new client per request.
- `tests/conftest.py`, `tests/test_classify.py`, `tests/test_main.py` — put mock vector store clients on `app.state`; add a test that both clients use the same HTTP client; avoid calling GCP during tests and avoid changing global `app.state` for later tests.

- [x] Feature implementation (feat:) / bug fix (fix:) / refactoring (chore:) / documentation (docs:) / testing (test:)
- [x] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

### Automated (this repo)

From `survey-assist-api` with dependencies installed:

```bash
make check-python-nofix
make all-tests
```

Expect 129 tests passing and coverage above 80%.

Key tests for this change:

```bash
poetry run pytest tests/test_main.py::test_vector_store_clients_share_http_client -v
poetry run pytest tests/test_classify.py -q
```

### Manual (local API + vector stores)

Start SIC and SOC vector store services, then the API with vector store URLs set:

```bash
export SIC_VECTOR_STORE="http://localhost:8088"
export SOC_VECTOR_STORE="http://localhost:8089"
poetry run uvicorn api.main:app --reload --port 8080
```

Verify classify still returns expected SIC/SOC results (for example electrician → SIC `43210`, farm hand → SOC `9111` when using full indexes), and that `/v1/survey-assist/embeddings` still returns vector store status.

### Behaviour unchanged

- Public API contracts, auth header handling, logging, and error responses for vector store calls are unchanged.
- Only client lifecycle and connection reuse differ: one shared HTTP client per process instead of a new client on each request.
