### PR TITLE
fix API startup failure when logging LLM model names at lifespan init

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -135,9 +135,13 @@ async def lifespan(fastapi_app: FastAPI):
     logger.info(
         "Application clients initialised",
         sic_llm=type(fastapi_app.state.gemini_llm).__name__,
-        sic_llm_model=fastapi_app.state.gemini_llm.model_name,
+        sic_llm_model=getattr(
+            fastapi_app.state.gemini_llm, "model_name", "gemini-2.5-flash"
+        ),
         soc_llm=type(fastapi_app.state.soc_llm).__name__,
-        soc_llm_model=fastapi_app.state.soc_llm.model_name,
+        soc_llm_model=getattr(
+            fastapi_app.state.soc_llm, "model_name", "gemini-2.5-flash"
+        ),
         sic_lookup_client=type(fastapi_app.state.sic_lookup_client).__name__,
         soc_lookup_client=type(fastapi_app.state.soc_lookup_client).__name__,
         sic_rephrase_client=type(fastapi_app.state.sic_rephrase_client).__name__,


### PR DESCRIPTION
# 📌 Pull Request Template

> **Please complete all sections**

## ✨ Summary

Fix local API startup failure introduced by SA-741 lifespan logging that accessed `model_name` on `ClassificationLLM`, which does not expose that attribute on the wrapper.

## 📜 Changes Introduced

- [x] bug fix (fix:)
- [ ] Updates to tests and/or documentation
- [ ] Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

- Run `make run-api` and confirm the app starts without `AttributeError: 'ClassificationLLM' object has no attribute 'model_name'`.
- Run `poetry run pytest tests/test_main.py -q`.
