### PR TITLE
feat(api): add SAYT client

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The API supports the following environment variables:
 
 - `GCP_PROJECT_ID`: Google Cloud Project ID
 - `FIRESTORE_DB_ID`: Firestore Database ID
+- `SAYT_SERVICE`: URL of the search as you type suggester service
 - `SIC_VECTOR_STORE`: URL of the vector store service
 - `SIC_VECTOR_STORE_AUTH_ENABLED`: Defaults to True. Set to False when the vector store runs locally or is a side-car deployment alongside the API in Cloud Run
 - `SIC_LOOKUP_DATA_PATH`: Path to SIC lookup data file

--- a/api/main.py
+++ b/api/main.py
@@ -24,6 +24,7 @@ from api.routes.v1.result import router as result_router
 from api.routes.v1.sic_lookup import router as sic_lookup_router
 from api.routes.v1.soc_lookup import router as soc_lookup_router
 from api.services.firestore_client import init_firestore_client
+from api.services.sayt_client import SAYTClient
 from api.services.sic_lookup_client import SICLookupClient
 from api.services.sic_rephrase_client import SICRephraseClient
 from api.services.sic_vector_store_client import SICVectorStoreClient
@@ -40,6 +41,7 @@ logger = get_logger(__name__)
 
 DEFAULT_SIC_VECTOR_STORE_URL = "http://localhost:8088"
 DEFAULT_SOC_VECTOR_STORE_URL = "http://localhost:8089"
+DEFAULT_SAYT_SERVICE_URL = "http://localhost:8090"
 
 
 def vector_store_auth_enabled(vector_store_name: str) -> bool:
@@ -96,6 +98,23 @@ def resolve_soc_vector_store_base_url() -> str:
         "SOC_VECTOR_STORE environment variable not set, using default localhost URL"
     )
     return DEFAULT_SOC_VECTOR_STORE_URL
+
+
+def resolve_sayt_service_base_url() -> str:
+    """Resolve the SAYT service base URL from environment or default."""
+    env_url = os.getenv("SAYT_SERVICE")
+
+    if env_url and env_url.strip():
+        logger.info(
+            f"Using SAYT service URL from environment: "
+            f"{env_url.strip().rstrip('/')}"
+        )
+        return env_url.strip().rstrip("/")
+
+    logger.warning(
+        "SAYT_SERVICE environment variable not set, using default localhost URL"
+    )
+    return DEFAULT_SAYT_SERVICE_URL
 
 
 @asynccontextmanager
@@ -163,9 +182,11 @@ async def lifespan(fastapi_app: FastAPI):
 
     sic_url = resolve_sic_vector_store_base_url()
     soc_url = resolve_soc_vector_store_base_url()
+    sayt_url = resolve_sayt_service_base_url()
 
     sic_token_provider = create_vector_store_token_provider("sic", sic_url)
     soc_token_provider = create_vector_store_token_provider("soc", soc_url)
+    sayt_token_provider = create_vector_store_token_provider("sayt", sayt_url)
 
     # Create SIC and SOC vector store clients with shared HTTP client and
     # separate token providers
@@ -180,6 +201,13 @@ async def lifespan(fastapi_app: FastAPI):
         http_client=shared_http_client,
         token_provider=soc_token_provider,
     )
+
+    fastapi_app.state.sayt_client = SAYTClient(
+        base_url=sayt_url,
+        http_client=shared_http_client,
+        token_provider=sayt_token_provider,
+    )
+
     logger.info(
         "Application clients initialised",
         sic_llm=type(fastapi_app.state.gemini_llm).__name__,
@@ -200,10 +228,12 @@ async def lifespan(fastapi_app: FastAPI):
         soc_vector_store_client=type(
             fastapi_app.state.soc_vector_store_client
         ).__name__,
+        sayt_client=type(fastapi_app.state.sayt_client).__name__,
         http_client=type(shared_http_client).__name__,
         vector_store_http_client_shared=str(
             fastapi_app.state.sic_vector_store_client.http_client
             is fastapi_app.state.soc_vector_store_client.http_client
+            is fastapi_app.state.sayt_client.http_client
         ),
     )
 

--- a/api/services/sayt_client.py
+++ b/api/services/sayt_client.py
@@ -1,0 +1,36 @@
+"""Client service for the SAYT API."""
+
+import httpx
+
+from api.services.token_provider import TokenProvider
+
+
+class SAYTClient:  # pylint: disable=too-few-public-methods
+    """Client for the SAYT service.
+
+    The client is initialised at application startup and provides the
+    dependencies required for future SAYT API requests.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        http_client: httpx.AsyncClient,
+        token_provider: TokenProvider,
+    ) -> None:
+        """Initialise the SAYT client.
+
+        Args:
+            base_url: Base URL of the SAYT service.
+            http_client: Shared async HTTP client for outbound requests.
+            token_provider: Provider for authentication tokens.
+        """
+        self.base_url = base_url
+        self._http_client = http_client
+        self._token_provider = token_provider
+
+    @property
+    def http_client(self) -> httpx.AsyncClient:
+        """Return the shared async HTTP client."""
+        return self._http_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from survey_assist_utils.logging import get_logger
 
 from api.main import app
 from api.models.embeddings import EMBEDDINGS_STATUS_EXAMPLE
+from api.services.sayt_client import SAYTClient
 from api.services.sic_lookup_client import SICLookupClient
 from api.services.sic_rephrase_client import SICRephraseClient
 from api.services.sic_vector_store_client import SICVectorStoreClient
@@ -86,6 +87,9 @@ def pytest_configure(config):  # pylint: disable=unused-argument
     app.state.soc_rephrase_client = mock_soc_rephrase_client
     app.state.sic_vector_store_client = mock_sic_vector_store_client
     app.state.soc_vector_store_client = mock_soc_vector_store_client
+
+    mock_sayt_client = MagicMock(spec=SAYTClient)
+    app.state.sayt_client = mock_sayt_client
 
     logger.info("Global Test Configuration Applied")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,11 +26,13 @@ from survey_assist_utils.logging import get_logger
 from api.main import (
     app,
     create_vector_store_token_provider,
+    resolve_sayt_service_base_url,
     resolve_sic_vector_store_base_url,
     resolve_soc_vector_store_base_url,
     vector_store_auth_enabled,
 )
 from api.models.embeddings import EMBEDDINGS_STATUS_EXAMPLE
+from api.services.sayt_client import SAYTClient
 from api.services.sic_vector_store_client import SICVectorStoreClient
 from api.services.soc_vector_store_client import SOCVectorStoreClient
 from api.services.token_provider import NoAuthTokenProvider
@@ -95,6 +97,24 @@ logger = get_logger(__name__)
             None,
             "http://localhost:8089",
         ),
+        (
+            "SAYT_SERVICE",
+            resolve_sayt_service_base_url,
+            "  http://sayt.internal:8090  ",
+            "http://sayt.internal:8090",
+        ),
+        (
+            "SAYT_SERVICE",
+            resolve_sayt_service_base_url,
+            "https://sayt.example/",
+            "https://sayt.example",
+        ),
+        (
+            "SAYT_SERVICE",
+            resolve_sayt_service_base_url,
+            None,
+            "http://localhost:8090",
+        ),
     ],
 )
 def test_resolve_vector_store_base_url_uses_expected_value(
@@ -115,11 +135,13 @@ def test_resolve_vector_store_base_url_uses_expected_value(
 
 @pytest.mark.api
 @pytest.mark.asyncio
-async def test_vector_store_clients_share_http_client():
+async def test_service_clients_share_http_client():
     """SIC and SOC vector store clients share one injected HTTP client."""
     shared_http_client = httpx.AsyncClient()
     sic_token_provider = AsyncMock()
     soc_token_provider = AsyncMock()
+    sayt_token_provider = AsyncMock()
+
     try:
         sic_client = SICVectorStoreClient(
             base_url=resolve_sic_vector_store_base_url(),
@@ -131,9 +153,15 @@ async def test_vector_store_clients_share_http_client():
             http_client=shared_http_client,
             token_provider=soc_token_provider,
         )
+        sayt_client = SAYTClient(
+            base_url=resolve_sayt_service_base_url(),
+            http_client=shared_http_client,
+            token_provider=sayt_token_provider,
+        )
 
         assert sic_client.http_client is shared_http_client
         assert soc_client.http_client is shared_http_client
+        assert sayt_client.http_client is shared_http_client
     finally:
         await shared_http_client.aclose()
 


### PR DESCRIPTION
# 📌 Minimal SAYT Client

## ✨ Summary

Adds the minimal scaffold required to introduce a Search As You Type (SAYT) client to the Survey Assist API.

The SAYT client is instantiated during application startup using the same shared HTTP client and authentication pattern as the existing SIC and SOC service clients. This change does not yet call the SAYT suggestions endpoint; it establishes the client, configuration and lifecycle required for future integration.

## 📜 Changes Introduced

* Added a lightweight `SAYTClient` service for future communication with the SAYT API.

* Added `SAYT_SERVICE` environment variable support for configuring the SAYT service base URL.

* Instantiated the SAYT client during Survey Assist API startup.

* Reused the existing shared `httpx.AsyncClient` and token-provider pattern used by the SIC and SOC clients.

* Added the SAYT client to application startup logging so its availability can be confirmed.

* Added pytest coverage for SAYT URL configuration and shared HTTP client usage.

* Updated the test application state with a mocked SAYT client.

* Documented the new `SAYT_SERVICE` environment variable in the README.

* [x] Feature implementation (feat:)

* [x] Updates to tests and/or documentation

## ✅ Checklist

* [x] Code is formatted using **Black**
* [x] Imports are sorted using **isort**
* [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
* [x] Security checks pass using **Bandit**
* [x] API and Unit tests are written and pass using **pytest**
* [x] DocStrings follow Google-style and are added as per Pylint recommendations
* [x] Documentation has been updated if needed

## 🔍 How to Test

Run the standard project checks and test suite:

```bash
make check-python
make all-tests
```

The SAYT-specific scaffold can also be verified by confirming that:

* `SAYT_SERVICE` is resolved and normalised correctly when configured.
* The localhost default is used when `SAYT_SERVICE` is not set.
* `SAYTClient` uses the same shared HTTP client as the SIC and SOC service clients.
* Starting the Survey Assist API successfully initialises the SAYT client and includes `SAYTClient` in the application client startup log.

No call to the SAYT `/suggestions` endpoint is expected as part of this change; endpoint integration will be added separately.
